### PR TITLE
Add ACE-specific AA capture presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,17 @@ model = MapAnything.from_pretrained(
 predictions = model.infer(views)
 
 # Retrieve (and optionally clear) the cached AA metadata. When a storage path is
-# configured, each entry contains the file system locations of the serialized
-# tensors for every alternating-attention block.
+# configured, the dictionary points at a single ``info_sharing_outputs.pt`` file
+# containing every alternating-attention block.
 aa_cache = model.get_info_sharing_intermediate_features(clear=True)
-print(aa_cache["final"]["features"][0]["path"])
+if aa_cache["storage_mode"] == "disk":
+    disk_payload = MapAnything.load_info_sharing_features_from_file(
+        aa_cache["storage_file"],
+        map_location="cpu",
+    )
+    print(disk_payload["final"].features[0].shape)
+else:
+    print(aa_cache["final"].features[0].shape)
 ```
 
 When using Hydra-based entry points (e.g., the benchmarking scripts), you can
@@ -209,7 +216,10 @@ so that images are always paired with ray directions, depths, and camera poses
 (including their metric scale factors) when AA tensors are recorded. They also
 set `info_sharing.module_args.indices` to `[0, ..., depth-1]` so every
 alternating-attention block is persisted to disk via `info_sharing_storage_path`.
-Apply the same override if you compose a custom Hydra run.
+When disk capture is enabled, all blocks for a forward pass are saved inside a
+single `info_sharing_outputs.pt` file that can be reloaded with
+`MapAnything.load_info_sharing_features_from_file`. Apply the same override if
+you compose a custom Hydra run.
 
 ### Multi-Modal Inference
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,52 @@ for i, pred in enumerate(predictions):
     img_no_norm = pred["img_no_norm"]         # Denormalized input images for visualization (B, H, W, 3)
 ```
 
+### Capturing Alternating-Attention Features
+
+MapAnything can optionally cache the alternating-attention (AA) transformer tensors
+emitted during a forward pass. Enable the storage flag either directly when
+instantiating the model or by selecting the dedicated Hydra config
+`model=mapanything_store_intermediates`:
+
+```python
+from pathlib import Path
+
+model = MapAnything.from_pretrained(
+    "facebook/map-anything",
+    store_info_sharing_intermediate_features=True,
+    info_sharing_storage_path=Path("aa_feature_cache"),
+).to(device)
+
+predictions = model.infer(views)
+
+# Retrieve (and optionally clear) the cached AA metadata. When a storage path is
+# configured, each entry contains the file system locations of the serialized
+# tensors for every alternating-attention block.
+aa_cache = model.get_info_sharing_intermediate_features(clear=True)
+print(aa_cache["final"]["features"][0]["path"])
+```
+
+When using Hydra-based entry points (e.g., the benchmarking scripts), you can
+select either of the helper presets depending on where you want the serialized
+tensors to live:
+
+- `model=mapanything_store_intermediates` pairs with
+  `bash_scripts/benchmark/dense_n_view/mapa_24v_store_intermediates.sh` and keeps
+  the cached tensors alongside the standard benchmarking outputs.
+- `model=mapanything_store_intermediates_ace` loads the ACE-oriented preset
+  (`configs/model/mapanything_store_intermediates_ace.yaml`) and the
+  accompanying helper script `bash_scripts/ace/ace_store_intermediates.sh`. This
+  variant writes alternating-attention blocks under
+  `${hydra:run.dir}/ACE/aa_blocks`, ensuring AA capture runs remain isolated
+  from the general benchmarking workspace.
+
+Both presets pin the task configuration to `model/task=images_and_full_geometry`
+so that images are always paired with ray directions, depths, and camera poses
+(including their metric scale factors) when AA tensors are recorded. They also
+set `info_sharing.module_args.indices` to `[0, ..., depth-1]` so every
+alternating-attention block is persisted to disk via `info_sharing_storage_path`.
+Apply the same override if you compose a custom Hydra run.
+
 ### Multi-Modal Inference
 
 MapAnything supports flexible combinations of geometric inputs for enhanced metric reconstruction. Steps to try it out:
@@ -352,11 +398,12 @@ predictions = model.infer(
 - `intrinsics` OR `ray_directions`: Camera calibration (cannot provide both since they are redundant)
 - `depth_z`: Z-depth maps (requires calibration info)
 - `camera_poses`: OpenCV (+X - Right, +Y - Down, +Z - Forward) cam2world poses as 4×4 matrices or (quaternions, translations)
+- `extrinsics`: Camera extrinsics as 3×4 or 4×4 matrices. Use `extrinsics_type` to specify whether matrices are `cam2world` (default) or `world_to_camera`/`w2c`.
 - `is_metric_scale`: Whether inputs are in metric scale
 
 **Key constraints for `model.infer`:**
 - If `depth_z` is provided, must also provide `intrinsics` or `ray_directions`
-- If any view has `camera_poses`, the first view (reference) must also have them
+- If any view has `camera_poses` or `extrinsics`, the first view (reference) must also have them
 - Cannot provide both `intrinsics` and `ray_directions` simultaneously (they are redundant)
 
 The above constraints are enforced in the inference API. However, if desired, the underlying `model.forward` can support any arbitrary combination of inputs (a total of 64 configurations; without counting per view flexibility).

--- a/bash_scripts/ace/ace_store_intermediates.sh
+++ b/bash_scripts/ace/ace_store_intermediates.sh
@@ -35,5 +35,5 @@ for combo in "${batch_sizes_and_views[@]}"; do
         +model.memory_efficient_inference=True \
         hydra.run.dir="$run_dir"
 
-    echo "Finished $dataset with ACE AA feature capture. Serialized tensors live under $run_dir/ACE/aa_blocks."
+    echo "Finished $dataset with ACE AA feature capture. Each run writes an info_sharing_outputs.pt file under $run_dir/ACE/aa_blocks."
 done

--- a/bash_scripts/ace/ace_store_intermediates.sh
+++ b/bash_scripts/ace/ace_store_intermediates.sh
@@ -11,7 +11,7 @@ export HYDRA_FULL_ERROR=1
 # Example batch size / view configuration for capturing alternating-attention features
 # while storing serialized tensors under the ACE workspace.
 batch_sizes_and_views=(
-    "1 100 benchmark_518_eth3d_snpp_tav2"
+    "1 2 benchmark_518_seven_scenes"
 )
 
 for combo in "${batch_sizes_and_views[@]}"; do

--- a/bash_scripts/ace/ace_store_intermediates.sh
+++ b/bash_scripts/ace/ace_store_intermediates.sh
@@ -27,6 +27,7 @@ for combo in "${batch_sizes_and_views[@]}"; do
         dataset=$dataset \
         dataset.num_workers=1 \
         dataset.num_views=$num_views \
+        +num_views=$num_views \
         batch_size=$batch_size \
         model=mapanything_store_intermediates_ace \
         model/task=images_and_full_geometry \

--- a/bash_scripts/ace/ace_store_intermediates.sh
+++ b/bash_scripts/ace/ace_store_intermediates.sh
@@ -19,7 +19,7 @@ for combo in "${batch_sizes_and_views[@]}"; do
 
     echo "Running $dataset with batch_size=$batch_size, num_views=$num_views (ACE AA feature capture enabled)"
 
-    run_dir="${root_experiments_dir}/ace_tasks/mapanything/${dataset}_${num_views}v_aa_capture"
+    run_dir_cli='${root_experiments_dir}/ace_tasks/mapanything/'"${dataset}"'_'"${num_views}"'v_aa_capture'
 
     python3 \
         benchmarking/dense_n_view/benchmark.py \
@@ -34,7 +34,7 @@ for combo in "${batch_sizes_and_views[@]}"; do
         model.encoder.uses_torch_hub=True \
         model.pretrained="${root_pretrained_checkpoints_dir}/facebook_map-anything.pth" \
         +model.memory_efficient_inference=True \
-        hydra.run.dir="$run_dir"
+        hydra.run.dir="$run_dir_cli"
 
-    echo "Finished $dataset with ACE AA feature capture. Each run writes an info_sharing_outputs.pt file under $run_dir/ACE/aa_blocks."
+    echo "Finished $dataset with ACE AA feature capture. Each run writes an info_sharing_outputs.pt file under ${run_dir_cli}/ACE/aa_blocks."
 done

--- a/bash_scripts/ace/ace_store_intermediates.sh
+++ b/bash_scripts/ace/ace_store_intermediates.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the Apache License, Version 2.0
+# found in the LICENSE file in the root directory of this source tree.
+
+set -euo pipefail
+export HYDRA_FULL_ERROR=1
+
+# Example batch size / view configuration for capturing alternating-attention features
+# while storing serialized tensors under the ACE workspace.
+batch_sizes_and_views=(
+    "1 100 benchmark_518_eth3d_snpp_tav2"
+)
+
+for combo in "${batch_sizes_and_views[@]}"; do
+    read -r batch_size num_views dataset <<< "$combo"
+
+    echo "Running $dataset with batch_size=$batch_size, num_views=$num_views (ACE AA feature capture enabled)"
+
+    run_dir="${root_experiments_dir}/ace_tasks/mapanything/${dataset}_${num_views}v_aa_capture"
+
+    python3 \
+        benchmarking/dense_n_view/benchmark.py \
+        machine=aws \
+        dataset=$dataset \
+        dataset.num_workers=1 \
+        dataset.num_views=$num_views \
+        batch_size=$batch_size \
+        model=mapanything_store_intermediates_ace \
+        model/task=images_and_full_geometry \
+        model.encoder.uses_torch_hub=True \
+        model.pretrained="${root_pretrained_checkpoints_dir}/facebook_map-anything.pth" \
+        +model.memory_efficient_inference=True \
+        hydra.run.dir="$run_dir"
+
+    echo "Finished $dataset with ACE AA feature capture. Serialized tensors live under $run_dir/ACE/aa_blocks."
+done

--- a/bash_scripts/benchmark/dense_n_view/mapa_24v_store_intermediates.sh
+++ b/bash_scripts/benchmark/dense_n_view/mapa_24v_store_intermediates.sh
@@ -26,6 +26,7 @@ for combo in "${batch_sizes_and_views[@]}"; do
         dataset=$dataset \
         dataset.num_workers=1 \
         dataset.num_views=$num_views \
+        +num_views=$num_views \
         batch_size=$batch_size \
         model=mapanything_store_intermediates \
         model/task=images_and_full_geometry \

--- a/bash_scripts/benchmark/dense_n_view/mapa_24v_store_intermediates.sh
+++ b/bash_scripts/benchmark/dense_n_view/mapa_24v_store_intermediates.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the Apache License, Version 2.0
+# found in the LICENSE file in the root directory of this source tree.
+
+set -euo pipefail
+export HYDRA_FULL_ERROR=1
+
+# Example batch size / view configuration for capturing alternating-attention features.
+batch_sizes_and_views=(
+    "1 100 benchmark_518_eth3d_snpp_tav2"
+)
+
+for combo in "${batch_sizes_and_views[@]}"; do
+    read -r batch_size num_views dataset <<< "$combo"
+
+    echo "Running $dataset with batch_size=$batch_size, num_views=$num_views (AA feature capture enabled)"
+
+    run_dir="${root_experiments_dir}/mapanything/benchmarking/dense_${num_views}_view/mapa_24v_store_intermediates"
+
+    python3 \
+        benchmarking/dense_n_view/benchmark.py \
+        machine=aws \
+        dataset=$dataset \
+        dataset.num_workers=1 \
+        dataset.num_views=$num_views \
+        batch_size=$batch_size \
+        model=mapanything_store_intermediates \
+        model/task=images_and_full_geometry \
+        model.encoder.uses_torch_hub=True \
+        model.pretrained="${root_pretrained_checkpoints_dir}/facebook_map-anything.pth" \
+        +model.memory_efficient_inference=True \
+        hydra.run.dir="$run_dir"
+
+    echo "Finished $dataset with AA feature capture. Serialized tensors live under $run_dir/aa_features."
+done

--- a/bash_scripts/benchmark/dense_n_view/mapa_24v_store_intermediates.sh
+++ b/bash_scripts/benchmark/dense_n_view/mapa_24v_store_intermediates.sh
@@ -10,7 +10,7 @@ export HYDRA_FULL_ERROR=1
 
 # Example batch size / view configuration for capturing alternating-attention features.
 batch_sizes_and_views=(
-    "1 100 benchmark_518_eth3d_snpp_tav2"
+    "1 2 benchmark_518_seven_scenes"
 )
 
 for combo in "${batch_sizes_and_views[@]}"; do

--- a/bash_scripts/benchmark/dense_n_view/mapa_24v_store_intermediates.sh
+++ b/bash_scripts/benchmark/dense_n_view/mapa_24v_store_intermediates.sh
@@ -18,7 +18,7 @@ for combo in "${batch_sizes_and_views[@]}"; do
 
     echo "Running $dataset with batch_size=$batch_size, num_views=$num_views (AA feature capture enabled)"
 
-    run_dir="${root_experiments_dir}/mapanything/benchmarking/dense_${num_views}_view/mapa_24v_store_intermediates"
+    run_dir_cli='${root_experiments_dir}/mapanything/benchmarking/dense_'"${num_views}"'_view/mapa_24v_store_intermediates'
 
     python3 \
         benchmarking/dense_n_view/benchmark.py \
@@ -33,7 +33,7 @@ for combo in "${batch_sizes_and_views[@]}"; do
         model.encoder.uses_torch_hub=True \
         model.pretrained="${root_pretrained_checkpoints_dir}/facebook_map-anything.pth" \
         +model.memory_efficient_inference=True \
-        hydra.run.dir="$run_dir"
+        hydra.run.dir="$run_dir_cli"
 
-    echo "Finished $dataset with AA feature capture. Each run writes an info_sharing_outputs.pt file under $run_dir/aa_features."
+    echo "Finished $dataset with AA feature capture. Each run writes an info_sharing_outputs.pt file under ${run_dir_cli}/aa_features."
 done

--- a/bash_scripts/benchmark/dense_n_view/mapa_24v_store_intermediates.sh
+++ b/bash_scripts/benchmark/dense_n_view/mapa_24v_store_intermediates.sh
@@ -34,5 +34,5 @@ for combo in "${batch_sizes_and_views[@]}"; do
         +model.memory_efficient_inference=True \
         hydra.run.dir="$run_dir"
 
-    echo "Finished $dataset with AA feature capture. Serialized tensors live under $run_dir/aa_features."
+    echo "Finished $dataset with AA feature capture. Each run writes an info_sharing_outputs.pt file under $run_dir/aa_features."
 done

--- a/bash_scripts/data_processing/seven_scenes_to_wai.sh
+++ b/bash_scripts/data_processing/seven_scenes_to_wai.sh
@@ -1,9 +1,42 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF' >&2
+Usage: seven_scenes_to_wai.sh [--datasets scene1[,scene2...]] <processed_root> <wai_output_dir> <conda_env> [conversion overrides...]
+  processed_root 目录需要包含 pgt_7scenes_* 子目录 (train/test/calibration/depth/poses/rgb)。
+  --datasets 支持用逗号分隔的场景列表，例如 --datasets chess 或 --datasets chess,heads。
+EOF
+}
+
+DATASET_FILTER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --datasets)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 1
+      fi
+      DATASET_FILTER="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 if [[ $# -lt 3 ]]; then
-  echo "Usage: $0 <processed_root> <wai_output_dir> <conda_env> [conversion overrides...]" >&2
-  echo "  processed_root 目录需要包含 pgt_7scenes_* 子目录 (train/test/calibration/depth/poses/rgb)。" >&2
+  usage
   exit 1
 fi
 
@@ -13,6 +46,22 @@ CONDA_ENV="$3"
 shift 3
 
 CONVERSION_OVERRIDES=("$@")
+
+if [[ -n "${DATASET_FILTER}" ]]; then
+  IFS=',' read -r -a _dataset_array <<< "${DATASET_FILTER}"
+  dataset_entries=()
+  for raw_name in "${_dataset_array[@]}"; do
+    name=${raw_name//[[:space:]]/}
+    if [[ -n "${name}" ]]; then
+      dataset_entries+=("'${name}'")
+    fi
+  done
+  if [[ ${#dataset_entries[@]} -gt 0 ]]; then
+    joined=$(printf '%s,' "${dataset_entries[@]}")
+    joined=${joined%,}
+    CONVERSION_OVERRIDES+=("dataset_whitelist=[${joined}]")
+  fi
+fi
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)

--- a/bash_scripts/data_processing/seven_scenes_to_wai.sh
+++ b/bash_scripts/data_processing/seven_scenes_to_wai.sh
@@ -3,13 +3,18 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF' >&2
-Usage: seven_scenes_to_wai.sh [--datasets scene1[,scene2...]] <processed_root> <wai_output_dir> <conda_env> [conversion overrides...]
+Usage: seven_scenes_to_wai.sh [--datasets scene1[,scene2...]] [--device DEVICE] [--moge-batch-size N] \
+                              <processed_root> <wai_output_dir> <conda_env> [conversion overrides...]
   processed_root 目录需要包含 pgt_7scenes_* 子目录 (train/test/calibration/depth/poses/rgb)。
   --datasets 支持用逗号分隔的场景列表，例如 --datasets chess 或 --datasets chess,heads。
+  --device 控制转换与后处理脚本使用的 PyTorch 设备（默认 cuda，可设置为 cpu、cuda:1 等）。
+  --moge-batch-size 指定 MoGe 推理批大小；默认保持配置文件中的设定。
 EOF
 }
 
 DATASET_FILTER=""
+DEVICE="cuda"
+MOGE_BATCH_SIZE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -19,6 +24,22 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       DATASET_FILTER="$2"
+      shift 2
+      ;;
+    --device)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 1
+      fi
+      DEVICE="$2"
+      shift 2
+      ;;
+    --moge-batch-size)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 1
+      fi
+      MOGE_BATCH_SIZE="$2"
       shift 2
       ;;
     -h|--help)
@@ -74,14 +95,24 @@ conda run -n "${CONDA_ENV}" \
   python -m wai_processing.scripts.conversion.seven_scenes \
   original_root="${PROCESSED_ROOT}" \
   root="${WAI_DIR}" \
+  device="${DEVICE}" \
   "${CONVERSION_OVERRIDES[@]}"
 
 conda run -n "${CONDA_ENV}" \
   python -m wai_processing.scripts.covisibility \
   "${REPO_ROOT}/data_processing/wai_processing/configs/covisibility/covisibility_gt_depth_224x224.yaml" \
+  root="${WAI_DIR}" \
+  device="${DEVICE}"
+
+MOGE_ARGS=(
   root="${WAI_DIR}"
+  device="${DEVICE}"
+)
+
+if [[ -n "${MOGE_BATCH_SIZE}" ]]; then
+  MOGE_ARGS+=("batch_size=${MOGE_BATCH_SIZE}")
+fi
 
 conda run -n "${CONDA_ENV}" \
   python -m wai_processing.scripts.run_moge \
-  root="${WAI_DIR}" \
-  batch_size=1
+  "${MOGE_ARGS[@]}"

--- a/bash_scripts/data_processing/seven_scenes_to_wai.sh
+++ b/bash_scripts/data_processing/seven_scenes_to_wai.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <processed_root> <wai_output_dir> <conda_env> [conversion overrides...]" >&2
+  echo "  processed_root 目录需要包含 pgt_7scenes_* 子目录 (train/test/calibration/depth/poses/rgb)。" >&2
+  exit 1
+fi
+
+PROCESSED_ROOT=$(realpath "$1")
+WAI_DIR=$(realpath "$2")
+CONDA_ENV="$3"
+shift 3
+
+CONVERSION_OVERRIDES=("$@")
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+mkdir -p "${WAI_DIR}"
+
+set -x
+
+conda run -n "${CONDA_ENV}" \
+  python -m wai_processing.scripts.conversion.seven_scenes \
+  original_root="${PROCESSED_ROOT}" \
+  root="${WAI_DIR}" \
+  "${CONVERSION_OVERRIDES[@]}"
+
+conda run -n "${CONDA_ENV}" \
+  python -m wai_processing.scripts.covisibility \
+  "${REPO_ROOT}/data_processing/wai_processing/configs/covisibility/covisibility_gt_depth_224x224.yaml" \
+  root="${WAI_DIR}"
+
+conda run -n "${CONDA_ENV}" \
+  python -m wai_processing.scripts.run_moge \
+  root="${WAI_DIR}" \
+  batch_size=1

--- a/bash_scripts/data_processing/seven_scenes_to_wai.sh
+++ b/bash_scripts/data_processing/seven_scenes_to_wai.sh
@@ -4,17 +4,20 @@ set -euo pipefail
 usage() {
   cat <<'EOF' >&2
 Usage: seven_scenes_to_wai.sh [--datasets scene1[,scene2...]] [--device DEVICE] [--moge-batch-size N] \
-                              <processed_root> <wai_output_dir> <conda_env> [conversion overrides...]
+                              [--moge-model PATH_OR_REPO] <processed_root> <wai_output_dir> <conda_env> \
+                              [conversion overrides...]
   processed_root 目录需要包含 pgt_7scenes_* 子目录 (train/test/calibration/depth/poses/rgb)。
   --datasets 支持用逗号分隔的场景列表，例如 --datasets chess 或 --datasets chess,heads。
   --device 控制转换与后处理脚本使用的 PyTorch 设备（默认 cuda，可设置为 cpu、cuda:1 等）。
   --moge-batch-size 指定 MoGe 推理批大小；默认保持配置文件中的设定。
+  --moge-model     覆盖 MoGe 权重位置，可填写本地 .pt 文件路径或 Hugging Face 仓库名。
 EOF
 }
 
 DATASET_FILTER=""
 DEVICE="cuda"
 MOGE_BATCH_SIZE=""
+MOGE_MODEL=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -40,6 +43,14 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       MOGE_BATCH_SIZE="$2"
+      shift 2
+      ;;
+    --moge-model)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 1
+      fi
+      MOGE_MODEL="$2"
       shift 2
       ;;
     -h|--help)
@@ -111,6 +122,10 @@ MOGE_ARGS=(
 
 if [[ -n "${MOGE_BATCH_SIZE}" ]]; then
   MOGE_ARGS+=("batch_size=${MOGE_BATCH_SIZE}")
+fi
+
+if [[ -n "${MOGE_MODEL}" ]]; then
+  MOGE_ARGS+=("model_path=${MOGE_MODEL}")
 fi
 
 conda run -n "${CONDA_ENV}" \

--- a/bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh
+++ b/bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh
@@ -1,11 +1,17 @@
-#!/usr/bin/env bash
+#!/bin/bash
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the Apache License, Version 2.0
+# found in the LICENSE file in the root directory of this source tree.
+
 set -euo pipefail
 export HYDRA_FULL_ERROR=1
 
 usage() {
-  cat <<'USAGE' >&2
+    cat <<'USAGE' >&2
 Usage: run_demo_reconstruction.sh [--device DEVICE] [--num-samples N] [--indices LIST] [--data-root PATH] \
-                                  <conda_env> <stored_feature_file> <output_root> [overrides...]
+                                  <stored_feature_file> <output_root> [overrides...]
   --device       Torch device passed to the demo (default: cuda)
   --num-samples  Number of dataset items to process (default: 1)
   --indices      Comma-separated dataset indices to process (overrides --num-samples)
@@ -19,74 +25,74 @@ INDICES=""
 DATA_ROOT=""
 
 while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --device)
-      [[ $# -ge 2 ]] || { usage; exit 1; }
-      DEVICE="$2"
-      shift 2
-      ;;
-    --num-samples)
-      [[ $# -ge 2 ]] || { usage; exit 1; }
-      NUM_SAMPLES="$2"
-      shift 2
-      ;;
-    --indices)
-      [[ $# -ge 2 ]] || { usage; exit 1; }
-      INDICES="$2"
-      shift 2
-      ;;
-    --data-root)
-      [[ $# -ge 2 ]] || { usage; exit 1; }
-      DATA_ROOT=$(realpath "$2")
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    --)
-      shift
-      break
-      ;;
-    *)
-      break
-      ;;
-  esac
+    case "$1" in
+        --device)
+            [[ $# -ge 2 ]] || { usage; exit 1; }
+            DEVICE="$2"
+            shift 2
+            ;;
+        --num-samples)
+            [[ $# -ge 2 ]] || { usage; exit 1; }
+            NUM_SAMPLES="$2"
+            shift 2
+            ;;
+        --indices)
+            [[ $# -ge 2 ]] || { usage; exit 1; }
+            INDICES="$2"
+            shift 2
+            ;;
+        --data-root)
+            [[ $# -ge 2 ]] || { usage; exit 1; }
+            DATA_ROOT=$(realpath "$2")
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            break
+            ;;
+    esac
 done
 
-if [[ $# -lt 3 ]]; then
-  usage
-  exit 1
+if [[ $# -lt 2 ]]; then
+    usage
+    exit 1
 fi
 
-CONDA_ENV="$1"
-STORED_FEATURE_FILE=$(realpath "$2")
-OUTPUT_ROOT=$(realpath "$3")
-shift 3
+STORED_FEATURE_FILE=$(realpath "$1")
+OUTPUT_ROOT=$(realpath "$2")
+shift 2
 
 EXTRA_OVERRIDES=("$@")
 
 mkdir -p "$OUTPUT_ROOT"
 
 CLI_ARGS=(
-  "fusion.stored_feature_file=$STORED_FEATURE_FILE"
-  "demo.output_dir=$OUTPUT_ROOT"
-  "demo.device=$DEVICE"
-  "demo.num_samples=$NUM_SAMPLES"
+    "fusion.stored_feature_file=${STORED_FEATURE_FILE}"
+    "demo.output_dir=${OUTPUT_ROOT}"
+    "demo.device=${DEVICE}"
+    "demo.num_samples=${NUM_SAMPLES}"
 )
 
-if [[ -n "$INDICES" ]]; then
-  CLI_ARGS+=("demo.sample_indices=[$INDICES]")
+if [[ -n "${INDICES}" ]]; then
+    CLI_ARGS+=("demo.sample_indices=[${INDICES}]")
 fi
 
-if [[ -n "$DATA_ROOT" ]]; then
-  CLI_ARGS+=("root_data_dir=$DATA_ROOT")
+if [[ -n "${DATA_ROOT}" ]]; then
+    CLI_ARGS+=("root_data_dir=${DATA_ROOT}")
 fi
 
 CLI_ARGS+=("${EXTRA_OVERRIDES[@]}")
 
 set -x
-conda run -n "$CONDA_ENV" python -m mapanything.tasks.aa_feature_fusion.demo "${CLI_ARGS[@]}"
+python3 -m mapanything.tasks.aa_feature_fusion.demo \
+    "${CLI_ARGS[@]}"
 set +x
 
-echo "Reconstruction artifacts written to $OUTPUT_ROOT"
+echo "Reconstruction artifacts written to ${OUTPUT_ROOT}"

--- a/bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh
+++ b/bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh
@@ -8,31 +8,26 @@
 set -euo pipefail
 export HYDRA_FULL_ERROR=1
 
-if [[ $# -lt 2 ]]; then
-  cat <<'USAGE' >&2
-Usage: run_demo_reconstruction.sh <stored_feature_file> <output_root> [overrides...]
+: "${STORED_FEATURE_FILE:?Set STORED_FEATURE_FILE to the info_sharing_outputs.pt path}"
+: "${OUTPUT_ROOT:?Set OUTPUT_ROOT to the reconstruction artifact directory}"
 
-Environment overrides:
-  DEVICE=cuda              # Torch device for the demo run
-  NUM_SAMPLES=1            # Number of dataset items to process
-  SAMPLE_INDICES=0,5,7     # Optional comma-separated indices (overrides NUM_SAMPLES)
-  DATA_ROOT=/path/to/wai   # Optional WAI dataset root passed as root_data_dir
-USAGE
-  exit 1
-fi
-
-STORED_FEATURE_FILE=$(realpath "$1")
-OUTPUT_ROOT=$(realpath "$2")
-shift 2
+STORED_FEATURE_FILE=$(realpath "${STORED_FEATURE_FILE}")
 
 mkdir -p "${OUTPUT_ROOT}"
+OUTPUT_ROOT=$(realpath "${OUTPUT_ROOT}")
 
 DEVICE=${DEVICE:-cuda}
 NUM_SAMPLES=${NUM_SAMPLES:-1}
 SAMPLE_INDICES=${SAMPLE_INDICES:-}
 DATA_ROOT=${DATA_ROOT:-}
+HYDRA_OVERRIDES=${HYDRA_OVERRIDES:-}
 
-HYDRA_ARGS=(
+EXTRA_OVERRIDES=()
+if [[ -n "${HYDRA_OVERRIDES}" ]]; then
+  read -r -a EXTRA_OVERRIDES <<< "${HYDRA_OVERRIDES}"
+fi
+
+PY_ARGS=(
   "fusion.stored_feature_file=${STORED_FEATURE_FILE}"
   "demo.output_dir=${OUTPUT_ROOT}"
   "demo.device=${DEVICE}"
@@ -40,16 +35,19 @@ HYDRA_ARGS=(
 )
 
 if [[ -n "${SAMPLE_INDICES}" ]]; then
-  HYDRA_ARGS+=("demo.sample_indices=[${SAMPLE_INDICES}]")
+  PY_ARGS+=("demo.sample_indices=[${SAMPLE_INDICES}]")
 fi
 
 if [[ -n "${DATA_ROOT}" ]]; then
-  HYDRA_ARGS+=("root_data_dir=${DATA_ROOT}")
+  PY_ARGS+=("root_data_dir=${DATA_ROOT}")
 fi
 
-HYDRA_ARGS+=("$@")
+if [[ ${#EXTRA_OVERRIDES[@]} -gt 0 ]]; then
+  PY_ARGS+=("${EXTRA_OVERRIDES[@]}")
+fi
 
-python3 -m mapanything.tasks.aa_feature_fusion.demo \
-  "${HYDRA_ARGS[@]}"
+python3 \
+  -m mapanything.tasks.aa_feature_fusion.demo \
+  "${PY_ARGS[@]}"
 
 echo "Reconstruction artifacts written to ${OUTPUT_ROOT}"

--- a/bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh
+++ b/bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export HYDRA_FULL_ERROR=1
+
+usage() {
+  cat <<'USAGE' >&2
+Usage: run_demo_reconstruction.sh [--device DEVICE] [--num-samples N] [--indices LIST] [--data-root PATH] \
+                                  <conda_env> <stored_feature_file> <output_root> [overrides...]
+  --device       Torch device passed to the demo (default: cuda)
+  --num-samples  Number of dataset items to process (default: 1)
+  --indices      Comma-separated dataset indices to process (overrides --num-samples)
+  --data-root    Root directory containing the converted WAI dataset
+USAGE
+}
+
+DEVICE="cuda"
+NUM_SAMPLES="1"
+INDICES=""
+DATA_ROOT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --device)
+      [[ $# -ge 2 ]] || { usage; exit 1; }
+      DEVICE="$2"
+      shift 2
+      ;;
+    --num-samples)
+      [[ $# -ge 2 ]] || { usage; exit 1; }
+      NUM_SAMPLES="$2"
+      shift 2
+      ;;
+    --indices)
+      [[ $# -ge 2 ]] || { usage; exit 1; }
+      INDICES="$2"
+      shift 2
+      ;;
+    --data-root)
+      [[ $# -ge 2 ]] || { usage; exit 1; }
+      DATA_ROOT=$(realpath "$2")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $# -lt 3 ]]; then
+  usage
+  exit 1
+fi
+
+CONDA_ENV="$1"
+STORED_FEATURE_FILE=$(realpath "$2")
+OUTPUT_ROOT=$(realpath "$3")
+shift 3
+
+EXTRA_OVERRIDES=("$@")
+
+mkdir -p "$OUTPUT_ROOT"
+
+CLI_ARGS=(
+  "fusion.stored_feature_file=$STORED_FEATURE_FILE"
+  "demo.output_dir=$OUTPUT_ROOT"
+  "demo.device=$DEVICE"
+  "demo.num_samples=$NUM_SAMPLES"
+)
+
+if [[ -n "$INDICES" ]]; then
+  CLI_ARGS+=("demo.sample_indices=[$INDICES]")
+fi
+
+if [[ -n "$DATA_ROOT" ]]; then
+  CLI_ARGS+=("root_data_dir=$DATA_ROOT")
+fi
+
+CLI_ARGS+=("${EXTRA_OVERRIDES[@]}")
+
+set -x
+conda run -n "$CONDA_ENV" python -m mapanything.tasks.aa_feature_fusion.demo "${CLI_ARGS[@]}"
+set +x
+
+echo "Reconstruction artifacts written to $OUTPUT_ROOT"

--- a/bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh
+++ b/bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh
@@ -8,91 +8,48 @@
 set -euo pipefail
 export HYDRA_FULL_ERROR=1
 
-usage() {
-    cat <<'USAGE' >&2
-Usage: run_demo_reconstruction.sh [--device DEVICE] [--num-samples N] [--indices LIST] [--data-root PATH] \
-                                  <stored_feature_file> <output_root> [overrides...]
-  --device       Torch device passed to the demo (default: cuda)
-  --num-samples  Number of dataset items to process (default: 1)
-  --indices      Comma-separated dataset indices to process (overrides --num-samples)
-  --data-root    Root directory containing the converted WAI dataset
-USAGE
-}
-
-DEVICE="cuda"
-NUM_SAMPLES="1"
-INDICES=""
-DATA_ROOT=""
-
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --device)
-            [[ $# -ge 2 ]] || { usage; exit 1; }
-            DEVICE="$2"
-            shift 2
-            ;;
-        --num-samples)
-            [[ $# -ge 2 ]] || { usage; exit 1; }
-            NUM_SAMPLES="$2"
-            shift 2
-            ;;
-        --indices)
-            [[ $# -ge 2 ]] || { usage; exit 1; }
-            INDICES="$2"
-            shift 2
-            ;;
-        --data-root)
-            [[ $# -ge 2 ]] || { usage; exit 1; }
-            DATA_ROOT=$(realpath "$2")
-            shift 2
-            ;;
-        -h|--help)
-            usage
-            exit 0
-            ;;
-        --)
-            shift
-            break
-            ;;
-        *)
-            break
-            ;;
-    esac
-done
-
 if [[ $# -lt 2 ]]; then
-    usage
-    exit 1
+  cat <<'USAGE' >&2
+Usage: run_demo_reconstruction.sh <stored_feature_file> <output_root> [overrides...]
+
+Environment overrides:
+  DEVICE=cuda              # Torch device for the demo run
+  NUM_SAMPLES=1            # Number of dataset items to process
+  SAMPLE_INDICES=0,5,7     # Optional comma-separated indices (overrides NUM_SAMPLES)
+  DATA_ROOT=/path/to/wai   # Optional WAI dataset root passed as root_data_dir
+USAGE
+  exit 1
 fi
 
 STORED_FEATURE_FILE=$(realpath "$1")
 OUTPUT_ROOT=$(realpath "$2")
 shift 2
 
-EXTRA_OVERRIDES=("$@")
+mkdir -p "${OUTPUT_ROOT}"
 
-mkdir -p "$OUTPUT_ROOT"
+DEVICE=${DEVICE:-cuda}
+NUM_SAMPLES=${NUM_SAMPLES:-1}
+SAMPLE_INDICES=${SAMPLE_INDICES:-}
+DATA_ROOT=${DATA_ROOT:-}
 
-CLI_ARGS=(
-    "fusion.stored_feature_file=${STORED_FEATURE_FILE}"
-    "demo.output_dir=${OUTPUT_ROOT}"
-    "demo.device=${DEVICE}"
-    "demo.num_samples=${NUM_SAMPLES}"
+HYDRA_ARGS=(
+  "fusion.stored_feature_file=${STORED_FEATURE_FILE}"
+  "demo.output_dir=${OUTPUT_ROOT}"
+  "demo.device=${DEVICE}"
+  "demo.num_samples=${NUM_SAMPLES}"
 )
 
-if [[ -n "${INDICES}" ]]; then
-    CLI_ARGS+=("demo.sample_indices=[${INDICES}]")
+if [[ -n "${SAMPLE_INDICES}" ]]; then
+  HYDRA_ARGS+=("demo.sample_indices=[${SAMPLE_INDICES}]")
 fi
 
 if [[ -n "${DATA_ROOT}" ]]; then
-    CLI_ARGS+=("root_data_dir=${DATA_ROOT}")
+  HYDRA_ARGS+=("root_data_dir=${DATA_ROOT}")
 fi
 
-CLI_ARGS+=("${EXTRA_OVERRIDES[@]}")
+HYDRA_ARGS+=("$@")
 
-set -x
 python3 -m mapanything.tasks.aa_feature_fusion.demo \
-    "${CLI_ARGS[@]}"
-set +x
+  "${HYDRA_ARGS[@]}"
 
 echo "Reconstruction artifacts written to ${OUTPUT_ROOT}"

--- a/configs/dataset/benchmark_518_seven_scenes.yaml
+++ b/configs/dataset/benchmark_518_seven_scenes.yaml
@@ -1,0 +1,13 @@
+defaults:
+  - default
+
+# Number of views parameter for the multi-view datasets
+num_views: 2
+
+# 7Scenes default evaluation resolution (640x480 -> 4:3 aspect ratio)
+resolution_test_seven_scenes: ${dataset.resolution_options.518_1_33_ar}
+
+# Test Set
+# Each sequence yields hundreds of frames; request 140 multi-view samples (~20 per scene)
+test_dataset:
+  "+ 140 @ ${dataset.seven_scenes_wai.test.dataset_str}"

--- a/configs/dataset/default.yaml
+++ b/configs/dataset/default.yaml
@@ -10,6 +10,7 @@ defaults:
   - mvs_synth_wai: default
   - paralleldomain4d_wai: default
   - sailvos3d_wai: default
+  - seven_scenes_wai: default
   - scannetpp_wai: default
   - spring_wai: default
   - tav2_wb_wai: default

--- a/configs/dataset/seven_scenes_wai/default.yaml
+++ b/configs/dataset/seven_scenes_wai/default.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - train: default
+  - val: default
+  - test: default

--- a/configs/dataset/seven_scenes_wai/test/default.yaml
+++ b/configs/dataset/seven_scenes_wai/test/default.yaml
@@ -1,0 +1,24 @@
+dataset_str:
+  "SevenScenesWAI(
+    split='${dataset.seven_scenes_wai.test.split}',
+    resolution=${dataset.seven_scenes_wai.test.dataset_resolution},
+    principal_point_centered=${dataset.seven_scenes_wai.test.principal_point_centered},
+    seed=${dataset.seven_scenes_wai.test.seed},
+    transform='${dataset.seven_scenes_wai.test.transform}',
+    data_norm_type='${dataset.seven_scenes_wai.test.data_norm_type}',
+    ROOT='${dataset.seven_scenes_wai.test.ROOT}',
+    dataset_metadata_dir='${dataset.seven_scenes_wai.test.dataset_metadata_dir}',
+    variable_num_views=${dataset.seven_scenes_wai.test.variable_num_views},
+    num_views=${dataset.seven_scenes_wai.test.num_views},
+    covisibility_thres=${dataset.seven_scenes_wai.test.covisibility_thres})"
+split: 'test'
+dataset_resolution: ${dataset.resolution_options.518_1_33_ar}
+principal_point_centered: ${dataset.principal_point_centered}
+seed: 777
+transform: 'imgnorm'
+data_norm_type: ${model.data_norm_type}
+ROOT: ${root_data_dir}/seven_scenes_wai
+dataset_metadata_dir: ${mapanything_dataset_metadata_dir}
+variable_num_views: ${dataset.test.variable_num_views}
+num_views: ${dataset.num_views}
+covisibility_thres: 0.0

--- a/configs/dataset/seven_scenes_wai/train/default.yaml
+++ b/configs/dataset/seven_scenes_wai/train/default.yaml
@@ -1,0 +1,26 @@
+dataset_str:
+  "SevenScenesWAI(
+    split='${dataset.seven_scenes_wai.train.split}',
+    resolution=${dataset.seven_scenes_wai.train.dataset_resolution},
+    principal_point_centered=${dataset.seven_scenes_wai.train.principal_point_centered},
+    aug_crop=${dataset.seven_scenes_wai.train.aug_crop},
+    transform='${dataset.seven_scenes_wai.train.transform}',
+    data_norm_type='${dataset.seven_scenes_wai.train.data_norm_type}',
+    ROOT='${dataset.seven_scenes_wai.train.ROOT}',
+    dataset_metadata_dir='${dataset.seven_scenes_wai.train.dataset_metadata_dir}',
+    overfit_num_sets=${dataset.seven_scenes_wai.train.overfit_num_sets},
+    variable_num_views=${dataset.seven_scenes_wai.train.variable_num_views},
+    num_views=${dataset.seven_scenes_wai.train.num_views},
+    covisibility_thres=${dataset.seven_scenes_wai.train.covisibility_thres})"
+split: 'train'
+dataset_resolution: ${dataset.resolution_train}
+principal_point_centered: ${dataset.principal_point_centered}
+aug_crop: 16
+transform: 'colorjitter+grayscale+gaublur'
+data_norm_type: ${model.data_norm_type}
+ROOT: ${root_data_dir}/seven_scenes_wai
+dataset_metadata_dir: ${mapanything_dataset_metadata_dir}
+overfit_num_sets: null
+variable_num_views: ${dataset.train.variable_num_views}
+num_views: ${dataset.num_views}
+covisibility_thres: 0.0

--- a/configs/dataset/seven_scenes_wai/val/default.yaml
+++ b/configs/dataset/seven_scenes_wai/val/default.yaml
@@ -1,0 +1,26 @@
+dataset_str:
+  "SevenScenesWAI(
+    split='${dataset.seven_scenes_wai.val.split}',
+    resolution=${dataset.seven_scenes_wai.val.dataset_resolution},
+    principal_point_centered=${dataset.seven_scenes_wai.val.principal_point_centered},
+    seed=${dataset.seven_scenes_wai.val.seed},
+    transform='${dataset.seven_scenes_wai.val.transform}',
+    data_norm_type='${dataset.seven_scenes_wai.val.data_norm_type}',
+    ROOT='${dataset.seven_scenes_wai.val.ROOT}',
+    dataset_metadata_dir='${dataset.seven_scenes_wai.val.dataset_metadata_dir}',
+    overfit_num_sets=${dataset.seven_scenes_wai.val.overfit_num_sets},
+    variable_num_views=${dataset.seven_scenes_wai.val.variable_num_views},
+    num_views=${dataset.seven_scenes_wai.val.num_views},
+    covisibility_thres=${dataset.seven_scenes_wai.val.covisibility_thres})"
+split: 'val'
+dataset_resolution: ${dataset.resolution_options.518_1_33_ar}
+principal_point_centered: ${dataset.principal_point_centered}
+seed: 777
+transform: 'imgnorm'
+data_norm_type: ${model.data_norm_type}
+ROOT: ${root_data_dir}/seven_scenes_wai
+dataset_metadata_dir: ${mapanything_dataset_metadata_dir}
+overfit_num_sets: null
+variable_num_views: ${dataset.val.variable_num_views}
+num_views: ${dataset.num_views}
+covisibility_thres: 0.0

--- a/configs/model/mapanything.yaml
+++ b/configs/model/mapanything.yaml
@@ -14,5 +14,11 @@ model_config:
   info_sharing_config: ${model.info_sharing}
   pred_head_config: ${model.pred_head}
   geometric_input_config: ${model.task}
+  # Toggle caching of alternating-attention features from MapAnything's info-sharing transformer.
+  store_info_sharing_intermediate_features: false
+  # Optional device where cached info-sharing tensors should be moved (e.g., "cpu").
+  info_sharing_storage_device: null
+  # Optional directory where cached info-sharing tensors should be serialized to disk.
+  info_sharing_storage_path: null
 # Image Normalization Type
 data_norm_type: ${model.encoder.data_norm_type}

--- a/configs/model/mapanything_store_intermediates.yaml
+++ b/configs/model/mapanything_store_intermediates.yaml
@@ -1,0 +1,26 @@
+# MapAnything configuration that enables caching alternating-attention transformer features
+# during inference. Derived from the default mapanything config with storage toggles enabled.
+defaults:
+  - default
+  - encoder: dinov2_large
+  - info_sharing: aat_ifr_24_layers
+  - pred_head: dpt_pose_scale
+  - task: images_and_full_geometry
+
+model_str: "mapanything"
+model_config:
+  name: "mapanything"
+  encoder_config: ${model.encoder}
+  info_sharing_config: ${model.info_sharing}
+  pred_head_config: ${model.pred_head}
+  geometric_input_config: ${model.task}
+  store_info_sharing_intermediate_features: true
+  info_sharing_storage_device: null
+  info_sharing_storage_path: "${hydra:run.dir}/aa_features"
+
+model:
+  info_sharing:
+    module_args:
+      indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+
+data_norm_type: ${model.encoder.data_norm_type}

--- a/configs/model/mapanything_store_intermediates_ace.yaml
+++ b/configs/model/mapanything_store_intermediates_ace.yaml
@@ -1,0 +1,27 @@
+# MapAnything configuration preset for ACE workflows that persist alternating-attention
+# transformer features to disk. Mirrors the default store_intermediates preset but saves
+# serialized tensors inside an ACE-scoped directory tree for easier organization.
+defaults:
+  - default
+  - encoder: dinov2_large
+  - info_sharing: aat_ifr_24_layers
+  - pred_head: dpt_pose_scale
+  - task: images_and_full_geometry
+
+model_str: "mapanything"
+model_config:
+  name: "mapanything"
+  encoder_config: ${model.encoder}
+  info_sharing_config: ${model.info_sharing}
+  pred_head_config: ${model.pred_head}
+  geometric_input_config: ${model.task}
+  store_info_sharing_intermediate_features: true
+  info_sharing_storage_device: null
+  info_sharing_storage_path: "${hydra:run.dir}/ACE/aa_blocks"
+
+model:
+  info_sharing:
+    module_args:
+      indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+
+data_norm_type: ${model.encoder.data_norm_type}

--- a/configs/model/task/images_and_full_geometry.yaml
+++ b/configs/model/task/images_and_full_geometry.yaml
@@ -1,0 +1,26 @@
+# MapAnything task configuration that always supplies all optional geometric inputs.
+# Ensures ray directions, depth maps, and camera poses (with their metric scale
+# factors) are provided alongside images during inference or evaluation runs.
+defaults:
+  - default
+
+# Overall Probability of Geometric Inputs
+overall_prob: 1
+# Dropout Probability of Geometric Inputs (for each sample across batch size and number of views)
+dropout_prob: 0
+# Probability of Geometric Inputs with Ray Directions
+ray_dirs_prob: 1
+# Probability of Geometric Inputs with Depths
+depth_prob: 1
+# Probability of Geometric Inputs with Camera Poses
+cam_prob: 1
+# Probability of sparsely sampling the high quality gt depth
+sparse_depth_prob: 0
+# Percentage of the valid depth to remove if the probability of using sparse depth is greater than 0 (Range: [0, 1])
+sparsification_removal_percent: 0
+# Probability for skipping input of the metric scale norm factor for the input metric high quality gt depth
+# If 0, the metric scale norm factor will be provided as input to the model for all the metric scale conditionings
+depth_scale_norm_all_prob: 0
+# Probability for skipping input of the metric scale norm factor for the input metric pose
+# If 0, the metric scale norm factor will be provided as input to the model for all the metric scale conditionings
+pose_scale_norm_all_prob: 0

--- a/configs/model/task/single_view_optional_intrinsics.yaml
+++ b/configs/model/task/single_view_optional_intrinsics.yaml
@@ -1,0 +1,18 @@
+# Task config tailored for single-view inference with optional geometric signals.
+defaults:
+  - default
+
+# Always enable deterministic sampling when geometric inputs are provided.
+overall_prob: 1.0
+# Disable random dropout of views/geometric modalities.
+dropout_prob: 0.0
+
+# Toggle individual modalities. These defaults mirror "images only" but keep
+# intrinsics available when supplied alongside the single view.
+ray_dirs_prob: 1.0
+depth_prob: 0.0
+cam_prob: 0.0
+sparse_depth_prob: 0.0
+sparsification_removal_percent: 0.0
+depth_scale_norm_all_prob: 0.0
+pose_scale_norm_all_prob: 0.0

--- a/configs/tasks/aa_feature_fusion/default.yaml
+++ b/configs/tasks/aa_feature_fusion/default.yaml
@@ -1,0 +1,27 @@
+# Base configuration for the AA feature fusion task pipeline.
+defaults:
+  - model: mapanything
+  - model/task: single_view_optional_intrinsics
+  - dataset: seven_scenes_wai/train/default
+  - _self_
+
+fusion:
+  stored_feature_file: null  # path to info_sharing_outputs.pt from a multi-view capture run
+  map_location: cpu
+  num_heads: 8
+  mlp_ratio: 4.0
+  dropout: 0.0
+
+single_view:
+  include_intrinsics: true
+  include_depth: false
+  include_pose: false
+  include_scale: false
+
+training:
+  max_epochs: 1
+  log_every_n_steps: 10
+  output_dir: ${hydra:run.dir}
+
+assessment:
+  notes: "Populate training/evaluation settings as the task matures."

--- a/configs/tasks/aa_feature_fusion/demo.yaml
+++ b/configs/tasks/aa_feature_fusion/demo.yaml
@@ -1,0 +1,18 @@
+# Demo configuration for running AA feature fusion reconstruction on 7Scenes.
+defaults:
+  - default
+  - dataset: seven_scenes_wai/test/default
+  - _self_
+
+dataset:
+  num_views: 1
+  test:
+    num_views: 1
+    variable_num_views: false
+
+demo:
+  device: cuda
+  num_samples: 1
+  sample_indices: null
+  output_dir: ${hydra:run.dir}/reconstruction
+  memory_efficient_inference: false

--- a/configs/tasks/aa_feature_fusion/test.yaml
+++ b/configs/tasks/aa_feature_fusion/test.yaml
@@ -1,0 +1,11 @@
+# Evaluation entrypoint for AA feature fusion.
+defaults:
+  - default
+  - dataset: seven_scenes_wai/test/default
+  - _self_
+
+evaluation:
+  batch_size: 1
+  num_workers: 2
+  output_dir: ${hydra:run.dir}
+  metrics: []

--- a/configs/tasks/aa_feature_fusion/train.yaml
+++ b/configs/tasks/aa_feature_fusion/train.yaml
@@ -1,0 +1,19 @@
+# Training entrypoint for AA feature fusion.
+defaults:
+  - default
+  - _self_
+
+training:
+  max_epochs: 10
+  log_every_n_steps: 20
+  output_dir: ${hydra:run.dir}
+
+optimizer:
+  name: adamw
+  learning_rate: 1e-4
+  weight_decay: 0.01
+
+scheduler:
+  name: cosine
+  warmup_steps: 1000
+  total_steps: 100000

--- a/data_processing/README.md
+++ b/data_processing/README.md
@@ -20,6 +20,7 @@ We also provide a HuggingFace dataset which contains the [pre-computed metadata]
 12. ✅ [Spring](https://spring-benchmark.org/)
 13. ✅ [TartanAirV2 Wide Baseline](https://uniflowmatch.github.io/)
 14. ✅ [UnrealStereo4K](https://github.com/fabiotosi92/SMD-Nets)
+15. ✅ [7Scenes](https://www.microsoft.com/en-us/research/project/rgb-d-dataset-7-scenes/)
 
 ## Download Instructions:
 
@@ -124,6 +125,37 @@ python -m wai_processing.scripts.covisibility \
 python -m wai_processing.scripts.run_moge \
           root="/fsx/xrtech/dryrun_tmp/eth3d" \
           batch_size=1 # MoGe stage doesn't support nested tensors
+```
+
+### Quick Start Example for 7Scenes
+
+The 7Scenes pipeline mirrors other RGB-D datasets but requires the
+`visloc_pseudo_gt_limitations` repository for pseudo ground-truth poses and per
+frame focal lengths. The helper script automates download, conversion, and the
+post-processing stages:
+
+```bash
+cd <path to map-anything>
+
+# Arguments: <processed_root> <wai_output_dir> <conda_env>
+bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
+          /mnt/storage/xwh/7Scenes \
+          /mnt/storage/xwh/mapanything-dataset/wai_data/7scenes \
+          wai_processing
+```
+
+To run the stages manually:
+
+```bash
+python data_processing/wai_processing/download_scripts/download_7scenes.py \
+          --target_dir /mnt/storage/xwh/7Scenes/downloads \
+          --extract_dir /mnt/storage/xwh/7Scenes/7scenes_source \
+          --pgt_dir /mnt/storage/xwh/7Scenes/visloc_pseudo_gt_limitations \
+          --stages download extract pgt
+
+python -m wai_processing.scripts.conversion.seven_scenes \
+          original_root=/mnt/storage/xwh/7Scenes \
+          root=/mnt/storage/xwh/mapanything-dataset/wai_data/7scenes
 ```
 
 ### Batch Processing using SLURM

--- a/data_processing/__init__.py
+++ b/data_processing/__init__.py
@@ -1,0 +1,6 @@
+"""Top-level package for data processing utilities and pipelines."""
+
+# The namespace is intentionally left light-weight so command line tools
+# can import modules like ``data_processing.wai_processing.utils`` when
+# executed directly via ``python path/to/script.py``.
+

--- a/data_processing/wai_processing/__init__.py
+++ b/data_processing/wai_processing/__init__.py
@@ -1,0 +1,6 @@
+"""WAI processing pipelines and helpers."""
+
+# Having an ``__init__`` file allows nested scripts to rely on absolute
+# imports such as ``from wai_processing.utils import download`` without
+# tweaking ``PYTHONPATH`` at runtime.
+

--- a/data_processing/wai_processing/configs/conversion/seven_scenes.yaml
+++ b/data_processing/wai_processing/configs/conversion/seven_scenes.yaml
@@ -10,6 +10,8 @@ image_width: 640
 image_height: 480
 invalid_depth_values: [0, 65535]
 
+device: cpu
+
 # Optional filters to accelerate smoke tests. Leave empty to process all scenes.
 dataset_whitelist: []  # e.g. [chess]
 split_whitelist: []    # e.g. [train]

--- a/data_processing/wai_processing/configs/conversion/seven_scenes.yaml
+++ b/data_processing/wai_processing/configs/conversion/seven_scenes.yaml
@@ -1,0 +1,14 @@
+original_root: # path containing pgt_7scenes_* folders (e.g. /mnt/storage/xwh/7Scenes)
+root: # target path for wai-formatted 7Scenes data
+
+dataset_name: seven_scenes
+version: 0.1
+overwrite: True
+
+default_focal_length: 585.0
+image_width: 640
+image_height: 480
+invalid_depth_values: [0, 65535]
+
+scene_filters:
+  - process_state_not: [conversion, finished]

--- a/data_processing/wai_processing/configs/conversion/seven_scenes.yaml
+++ b/data_processing/wai_processing/configs/conversion/seven_scenes.yaml
@@ -10,5 +10,10 @@ image_width: 640
 image_height: 480
 invalid_depth_values: [0, 65535]
 
+# Optional filters to accelerate smoke tests. Leave empty to process all scenes.
+dataset_whitelist: []  # e.g. [chess]
+split_whitelist: []    # e.g. [train]
+sequence_whitelist: [] # e.g. [chess/train/seq-01]
+
 scene_filters:
   - process_state_not: [conversion, finished]

--- a/data_processing/wai_processing/configs/launch/seven_scenes.yaml
+++ b/data_processing/wai_processing/configs/launch/seven_scenes.yaml
@@ -1,0 +1,23 @@
+stage: # set stage via CLI
+root: # path of wai-formatted dataset
+
+gpus: 0
+cpus: 10
+mem: 20
+scenes_per_job: 50
+conda_env: # name of the wai-processing conda environment
+nodelist:
+
+stages:
+  conversion:
+    script: conversion/seven_scenes.py
+    config: conversion/seven_scenes.yaml
+  covisibility:
+    script: covisibility.py
+    config: covisibility/covisibility_gt_depth_224x224.yaml
+    gpus: 1
+  moge:
+    script: run_moge.py
+    config: moge/default.yaml
+    additional_cli_params: ['batch_size=1']
+    gpus: 1

--- a/data_processing/wai_processing/configs/moge/default.yaml
+++ b/data_processing/wai_processing/configs/moge/default.yaml
@@ -1,6 +1,6 @@
 root: # needs to be set via argument: root=<wai_dataset_root_path>
 
-model_path: /fsx/xrtech/checkpoints/MoGe/moge-2-vitl-normal/model.pt
+model_path: Ruicheng/moge-2-vitl-normal
 model_name: moge2
 out_path: moge/v0
 device: cuda

--- a/data_processing/wai_processing/download_scripts/README.md
+++ b/data_processing/wai_processing/download_scripts/README.md
@@ -56,5 +56,6 @@ Use the provided python script `download_unrealstereo4k.py`.
 
 ## 7Scenes
 Use the provided python script `download_7scenes.py` to grab the RGB-D sequences
-and clone the pseudo ground-truth repository.
+and clone the pseudo ground-truth repository. Pass `--scenes chess` (or a
+space-separated list) to quickly download a subset for smoke testing.
 **Source:** [7Scenes](https://www.microsoft.com/en-us/research/project/rgb-d-dataset-7-scenes/)

--- a/data_processing/wai_processing/download_scripts/README.md
+++ b/data_processing/wai_processing/download_scripts/README.md
@@ -53,3 +53,8 @@ Use the provided python script `download_tav2_wb.py`.
 ## UnrealStereo4K
 Use the provided python script `download_unrealstereo4k.py`.
 **Source:** [UnrealStereo4K](https://github.com/fabiotosi92/SMD-Nets?tab=readme-ov-file#datasets)
+
+## 7Scenes
+Use the provided python script `download_7scenes.py` to grab the RGB-D sequences
+and clone the pseudo ground-truth repository.
+**Source:** [7Scenes](https://www.microsoft.com/en-us/research/project/rgb-d-dataset-7-scenes/)

--- a/data_processing/wai_processing/download_scripts/download_7scenes.py
+++ b/data_processing/wai_processing/download_scripts/download_7scenes.py
@@ -49,6 +49,27 @@ def _collect_all_zips(target_dir: Path) -> Iterable[Path]:
         yield path
 
 
+def _scene_is_already_extracted(extract_dir: Path, scene: str) -> bool:
+    """Return True when the scene folder looks fully extracted."""
+
+    scene_dir = extract_dir / scene
+    if not scene_dir.is_dir():
+        return False
+
+    has_sequences = any(
+        child.is_dir() and child.name.startswith("seq-") for child in scene_dir.iterdir()
+    )
+    if not has_sequences:
+        return False
+
+    has_splits = any(
+        child.is_file()
+        and child.name.lower() in {"trainsplit.txt", "testsplit.txt"}
+        for child in scene_dir.iterdir()
+    )
+    return has_splits
+
+
 def _clone_visloc_repo(dest: Path, update: bool) -> None:
     """Clone or update the visloc pseudo-GT repository."""
     if dest.exists():
@@ -133,12 +154,25 @@ def main() -> None:
         selected_scenes = None
 
     if run_all or "download" in stages:
-        print("Downloading 7Scenes archives ...")
-        parallel_download(
-            target_dir,
-            build_download_map(selected_scenes),
-            n_workers=args.n_workers,
-        )
+        download_map = build_download_map(selected_scenes)
+        if extract_dir.exists():
+            download_map = {
+                name: url
+                for name, url in download_map.items()
+                if not _scene_is_already_extracted(extract_dir, Path(name).stem)
+            }
+        if download_map:
+            print("Downloading 7Scenes archives ...")
+            parallel_download(
+                target_dir,
+                download_map,
+                n_workers=args.n_workers,
+            )
+        else:
+            print(
+                "All requested scenes already exist in"
+                f" {extract_dir}. Skipping download stage."
+            )
 
     if run_all or "extract" in stages:
         print("Extracting scene archives ...")
@@ -146,6 +180,12 @@ def main() -> None:
         for archive_name in build_download_map(selected_scenes):
             archive_path = target_dir / archive_name
             scene_extract_dir = extract_dir / archive_path.stem
+            if _scene_is_already_extracted(extract_dir, archive_path.stem):
+                print(
+                    f"Scene '{archive_path.stem}' already extracted at"
+                    f" {scene_extract_dir}, skipping."
+                )
+                continue
             scene_extract_dir.mkdir(parents=True, exist_ok=True)
             extract_zip_archives(
                 archive_path.parent,

--- a/data_processing/wai_processing/download_scripts/download_7scenes.py
+++ b/data_processing/wai_processing/download_scripts/download_7scenes.py
@@ -29,9 +29,11 @@ BASE_URL = (
 VISLOC_REPO_URL = "https://github.com/tsattler/visloc_pseudo_gt_limitations.git"
 
 
-def build_download_map() -> dict[str, str]:
+def build_download_map(selected_scenes: Iterable[str] | None = None) -> dict[str, str]:
     """Return a mapping from archive names to their download URLs."""
-    return {f"{scene}.zip": f"{BASE_URL}/{scene}.zip" for scene in SCENE_NAMES}
+
+    scenes = list(selected_scenes) if selected_scenes else list(SCENE_NAMES)
+    return {f"{scene}.zip": f"{BASE_URL}/{scene}.zip" for scene in scenes}
 
 
 def _collect_all_zips(target_dir: Path) -> Iterable[Path]:
@@ -89,6 +91,15 @@ def main() -> None:
         help="Pipeline stages to run.",
     )
     parser.add_argument(
+        "--scenes",
+        nargs="+",
+        choices=SCENE_NAMES,
+        help=(
+            "Optional subset of scene names to download/extract. Defaults to all "
+            "7Scenes sequences when omitted."
+        ),
+    )
+    parser.add_argument(
         "--update_pgt",
         action="store_true",
         help="Update an existing pseudo-GT clone by running 'git pull'.",
@@ -107,14 +118,24 @@ def main() -> None:
     stages = set(args.stages)
     run_all = "all" in stages
 
+    if args.scenes:
+        selected_scenes = tuple(dict.fromkeys(args.scenes))
+        print(f"Restricting download/extraction to scenes: {', '.join(selected_scenes)}")
+    else:
+        selected_scenes = None
+
     if run_all or "download" in stages:
         print("Downloading 7Scenes archives ...")
-        parallel_download(target_dir, build_download_map(), n_workers=args.n_workers)
+        parallel_download(
+            target_dir,
+            build_download_map(selected_scenes),
+            n_workers=args.n_workers,
+        )
 
     if run_all or "extract" in stages:
         print("Extracting scene archives ...")
         extract_dir.mkdir(parents=True, exist_ok=True)
-        for archive_name in build_download_map():
+        for archive_name in build_download_map(selected_scenes):
             archive_path = target_dir / archive_name
             scene_extract_dir = extract_dir / archive_path.stem
             scene_extract_dir.mkdir(parents=True, exist_ok=True)

--- a/data_processing/wai_processing/download_scripts/download_7scenes.py
+++ b/data_processing/wai_processing/download_scripts/download_7scenes.py
@@ -6,10 +6,18 @@
 
 import argparse
 import subprocess
+import sys
 from pathlib import Path
 from typing import Iterable
 
-from wai_processing.utils.download import extract_zip_archives, parallel_download
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from data_processing.wai_processing.utils.download import (
+    extract_zip_archives,
+    parallel_download,
+)
 
 SCENE_NAMES: tuple[str, ...] = (
     "chess",

--- a/data_processing/wai_processing/download_scripts/download_7scenes.py
+++ b/data_processing/wai_processing/download_scripts/download_7scenes.py
@@ -1,0 +1,151 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the Apache License, Version 2.0
+# found in the LICENSE file in the root directory of this source tree.
+"""Download helper for the 7Scenes dataset and pseudo ground-truth poses."""
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+from wai_processing.utils.download import extract_zip_archives, parallel_download
+
+SCENE_NAMES: tuple[str, ...] = (
+    "chess",
+    "fire",
+    "heads",
+    "office",
+    "pumpkin",
+    "redkitchen",
+    "stairs",
+)
+
+BASE_URL = (
+    "http://download.microsoft.com/download/2/8/5/"
+    "28564B23-0828-408F-8631-23B1EFF1DAC8"
+)
+
+VISLOC_REPO_URL = "https://github.com/tsattler/visloc_pseudo_gt_limitations.git"
+
+
+def build_download_map() -> dict[str, str]:
+    """Return a mapping from archive names to their download URLs."""
+    return {f"{scene}.zip": f"{BASE_URL}/{scene}.zip" for scene in SCENE_NAMES}
+
+
+def _collect_all_zips(target_dir: Path) -> Iterable[Path]:
+    for path in target_dir.rglob("*.zip"):
+        yield path
+
+
+def _clone_visloc_repo(dest: Path, update: bool) -> None:
+    """Clone or update the visloc pseudo-GT repository."""
+    if dest.exists():
+        if not update:
+            print(f"visloc pseudo-GT repo already exists at {dest}, skipping clone.")
+            return
+        print(f"Updating visloc pseudo-GT repo in {dest}...")
+        subprocess.run(["git", "-C", str(dest), "pull", "--ff-only"], check=True)
+        return
+
+    print(f"Cloning visloc pseudo-GT repo into {dest} ...")
+    subprocess.run(["git", "clone", VISLOC_REPO_URL, str(dest)], check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download the original 7Scenes RGB-D sequences and the pseudo ground-"
+            "truth repository used for PGT poses."
+        )
+    )
+    parser.add_argument(
+        "--target_dir",
+        required=True,
+        help="Directory where the raw scene archives should be downloaded.",
+    )
+    parser.add_argument(
+        "--extract_dir",
+        default=None,
+        help="Directory where the RGB-D sequences should be unpacked.",
+    )
+    parser.add_argument(
+        "--pgt_dir",
+        default=None,
+        help="Optional path where the visloc pseudo-GT repository should be cloned.",
+    )
+    parser.add_argument(
+        "--n_workers",
+        type=int,
+        default=8,
+        help="Number of parallel workers for downloading and extraction.",
+    )
+    parser.add_argument(
+        "--stages",
+        nargs="+",
+        default=["all"],
+        choices=["download", "extract", "pgt", "cleanup", "all"],
+        help="Pipeline stages to run.",
+    )
+    parser.add_argument(
+        "--update_pgt",
+        action="store_true",
+        help="Update an existing pseudo-GT clone by running 'git pull'.",
+    )
+    parser.add_argument(
+        "--delete_archives",
+        action="store_true",
+        help="Remove downloaded zip files after extraction completes.",
+    )
+
+    args = parser.parse_args()
+    target_dir = Path(args.target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    extract_dir = Path(args.extract_dir) if args.extract_dir else target_dir / "extracted"
+    stages = set(args.stages)
+    run_all = "all" in stages
+
+    if run_all or "download" in stages:
+        print("Downloading 7Scenes archives ...")
+        parallel_download(target_dir, build_download_map(), n_workers=args.n_workers)
+
+    if run_all or "extract" in stages:
+        print("Extracting scene archives ...")
+        extract_dir.mkdir(parents=True, exist_ok=True)
+        for archive_name in build_download_map():
+            archive_path = target_dir / archive_name
+            scene_extract_dir = extract_dir / archive_path.stem
+            scene_extract_dir.mkdir(parents=True, exist_ok=True)
+            extract_zip_archives(
+                archive_path.parent,
+                scene_extract_dir,
+                n_workers=args.n_workers,
+            )
+            for nested_zip in list(scene_extract_dir.glob("*.zip")):
+                nested_target = nested_zip.with_suffix("")
+                extract_zip_archives(
+                    nested_zip.parent,
+                    nested_target,
+                    n_workers=1,
+                )
+                nested_zip.unlink()
+
+    if run_all or "cleanup" in stages:
+        if args.delete_archives:
+            print("Removing downloaded archives ...")
+            for zip_path in _collect_all_zips(target_dir):
+                try:
+                    zip_path.unlink()
+                except OSError as exc:
+                    print(f"Warning: failed to delete {zip_path}: {exc}")
+        else:
+            print("Cleanup stage requested without --delete_archives; skipping archive removal.")
+
+    if (run_all or "pgt" in stages) and args.pgt_dir:
+        _clone_visloc_repo(Path(args.pgt_dir), update=args.update_pgt)
+
+
+if __name__ == "__main__":
+    main()

--- a/data_processing/wai_processing/scripts/conversion/seven_scenes.py
+++ b/data_processing/wai_processing/scripts/conversion/seven_scenes.py
@@ -116,14 +116,22 @@ def _parse_calibration(calib_path: Path, cfg) -> tuple[float, float, float, floa
     return float(fx), float(fy), float(cx), float(cy)
 
 
-def _load_depth(depth_path: Path, invalid_values: set[int]) -> np.ndarray:
+def _load_depth(
+    depth_path: Path, invalid_values: set[int], device: torch.device
+) -> np.ndarray:
     with Image.open(depth_path) as depth_pil:
-        depth = np.array(depth_pil, dtype=np.uint16)
-    mask = np.isin(depth, list(invalid_values))
-    depth = depth.astype(np.float32)
-    depth[mask] = 0.0
+        depth_np = np.array(depth_pil, dtype=np.uint16)
+
+    depth = torch.from_numpy(depth_np).to(device=device, dtype=torch.float32)
+
+    if invalid_values:
+        invalid_mask = torch.zeros_like(depth, dtype=torch.bool)
+        for value in invalid_values:
+            invalid_mask |= depth == float(value)
+        depth = depth.masked_fill(invalid_mask, 0.0)
+
     depth *= 1.0 / 1000.0
-    return depth
+    return depth.cpu().numpy()
 
 
 def _sequence_filters(cfg):
@@ -159,6 +167,15 @@ def process_seven_scenes_scene(cfg, scene_key: str):
     depth_out_dir.mkdir(parents=True, exist_ok=True)
 
     invalid_values = set(cfg.get("invalid_depth_values", [0, 65535]))
+    requested_device = cfg.get("device", "cpu")
+    if str(requested_device).startswith("cuda") and not torch.cuda.is_available():
+        logger.warning(
+            "CUDA 不可用，转换流程将改为在 CPU 上执行 (请求的设备为 %s)",
+            requested_device,
+        )
+        device = torch.device("cpu")
+    else:
+        device = torch.device(requested_device)
     sequence_whitelist_full, sequence_whitelist_short = _sequence_filters(cfg)
 
     image_files = natsorted(rgb_dir.glob(f"*{RGB_SUFFIX}"))
@@ -208,7 +225,7 @@ def process_seven_scenes_scene(cfg, scene_key: str):
         if not target_image_path.exists():
             target_image_path.symlink_to(image_path.resolve())
 
-        depth = _load_depth(depth_path, invalid_values)
+        depth = _load_depth(depth_path, invalid_values, device)
         rel_depth_path = Path("depth") / f"{base_name}.exr"
         store_data(target_scene_root / rel_depth_path, torch.from_numpy(depth), "depth")
 

--- a/data_processing/wai_processing/scripts/conversion/seven_scenes.py
+++ b/data_processing/wai_processing/scripts/conversion/seven_scenes.py
@@ -1,0 +1,189 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the Apache License, Version 2.0
+# found in the LICENSE file in the root directory of this source tree.
+"""Convert 7Scenes data laid out like ``pgt_7scenes_*`` folders into WAI format."""
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import torch
+from argconf import argconf_parse
+from mapanything.utils.wai.core import store_data
+from natsort import natsorted
+from PIL import Image
+from wai_processing.utils.globals import WAI_PROC_CONFIG_PATH
+from wai_processing.utils.wrapper import convert_scenes_wrapper
+
+logger = logging.getLogger(__name__)
+
+RGB_SUFFIX = ".color.png"
+DEPTH_SUFFIX = ".depth.png"
+POSE_SUFFIX = ".pose.txt"
+CALIB_SUFFIX = ".calibration.txt"
+
+
+def _discover_scene_keys(cfg) -> list[str]:
+    original_root = Path(cfg.original_root)
+    scene_keys: list[str] = []
+    for scene_dir in sorted(original_root.glob("pgt_7scenes_*")):
+        if not scene_dir.is_dir():
+            continue
+        dataset_name = scene_dir.name.replace("pgt_7scenes_", "", 1)
+        for split_dir in sorted(scene_dir.iterdir()):
+            if not split_dir.is_dir():
+                continue
+            rgb_dir = split_dir / "rgb"
+            if not rgb_dir.exists():
+                logger.warning("Skipping %s; missing rgb/ directory", split_dir)
+                continue
+            for image_file in natsorted(rgb_dir.glob(f"*{RGB_SUFFIX}")):
+                prefix = image_file.name.replace(RGB_SUFFIX, "")
+                seq_name = prefix.split("-frame")[0]
+                scene_key = f"{dataset_name}/{split_dir.name}/{seq_name}"
+                if scene_key not in scene_keys:
+                    scene_keys.append(scene_key)
+    return scene_keys
+
+
+def _parse_calibration(calib_path: Path, cfg) -> tuple[float, float, float, float]:
+    if not calib_path.exists():
+        fx = fy = float(cfg.default_focal_length)
+        cx = float(cfg.image_width) / 2.0
+        cy = float(cfg.image_height) / 2.0
+        return fx, fy, cx, cy
+
+    with open(calib_path, "r", encoding="utf-8") as handle:
+        values: list[float] = []
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            parts = stripped.replace(",", " ").split()
+            values.extend(float(part) for part in parts)
+    if not values:
+        fx = fy = float(cfg.default_focal_length)
+        cx = float(cfg.image_width) / 2.0
+        cy = float(cfg.image_height) / 2.0
+        return fx, fy, cx, cy
+
+    if len(values) == 1:
+        fx = fy = values[0]
+    else:
+        fx, fy = values[0], values[1]
+    if len(values) >= 4:
+        cx, cy = values[2], values[3]
+    else:
+        cx = float(cfg.image_width) / 2.0
+        cy = float(cfg.image_height) / 2.0
+    return float(fx), float(fy), float(cx), float(cy)
+
+
+def _load_depth(depth_path: Path, invalid_values: set[int]) -> np.ndarray:
+    with Image.open(depth_path) as depth_pil:
+        depth = np.array(depth_pil, dtype=np.uint16)
+    mask = np.isin(depth, list(invalid_values))
+    depth = depth.astype(np.float32)
+    depth[mask] = 0.0
+    depth *= 1.0 / 1000.0
+    return depth
+
+
+def process_seven_scenes_scene(cfg, scene_key: str):
+    dataset_name, split, sequence = scene_key.split("/")
+    source_root = Path(cfg.original_root) / f"pgt_7scenes_{dataset_name}" / split
+
+    rgb_dir = source_root / "rgb"
+    depth_dir = source_root / "depth"
+    pose_dir = source_root / "poses"
+    calib_dir = source_root / "calibration"
+
+    if not rgb_dir.exists():
+        raise FileNotFoundError(f"Missing rgb directory at {rgb_dir}")
+
+    wai_scene_name = f"{dataset_name}_{split}_{sequence}"
+    target_scene_root = Path(cfg.root) / wai_scene_name
+    image_dir = target_scene_root / "images"
+    depth_out_dir = target_scene_root / "depth"
+    image_dir.mkdir(parents=True, exist_ok=True)
+    depth_out_dir.mkdir(parents=True, exist_ok=True)
+
+    invalid_values = set(cfg.get("invalid_depth_values", [0, 65535]))
+
+    image_files = natsorted(rgb_dir.glob(f"{sequence}-frame-*{RGB_SUFFIX}"))
+    if not image_files:
+        logger.warning("No frames found for %s", scene_key)
+        return "finished", "empty_sequence"
+
+    frames = []
+    for image_path in image_files:
+        base_name = image_path.name.replace(RGB_SUFFIX, "")
+        depth_path = depth_dir / f"{base_name}{DEPTH_SUFFIX}"
+        pose_path = pose_dir / f"{base_name}{POSE_SUFFIX}"
+        calib_path = calib_dir / f"{base_name}{CALIB_SUFFIX}"
+
+        if not depth_path.exists():
+            logger.warning("Missing depth for %s, skipping frame", base_name)
+            continue
+        if not pose_path.exists():
+            logger.warning("Missing pose for %s, skipping frame", base_name)
+            continue
+
+        target_image_path = image_dir / image_path.name
+        if target_image_path.exists():
+            target_image_path.unlink()
+        target_image_path.symlink_to(image_path.resolve())
+
+        depth = _load_depth(depth_path, invalid_values)
+        rel_depth_path = Path("depth") / f"{base_name}.exr"
+        store_data(target_scene_root / rel_depth_path, torch.from_numpy(depth), "depth")
+
+        pose = np.loadtxt(pose_path, dtype=np.float32).reshape(4, 4)
+        fx, fy, cx, cy = _parse_calibration(calib_path, cfg)
+
+        frame_entry = {
+            "frame_name": base_name,
+            "image": str(Path("images") / image_path.name),
+            "file_path": str(Path("images") / image_path.name),
+            "depth": str(rel_depth_path),
+            "transform_matrix": pose.tolist(),
+            "h": int(depth.shape[0]),
+            "w": int(depth.shape[1]),
+            "fl_x": float(fx),
+            "fl_y": float(fy),
+            "cx": float(cx),
+            "cy": float(cy),
+        }
+        frames.append(frame_entry)
+
+    if not frames:
+        logger.warning("All frames skipped for %s", scene_key)
+        return "finished", "no_valid_frames"
+
+    scene_meta = {
+        "scene_name": wai_scene_name,
+        "dataset_name": cfg.dataset_name,
+        "version": cfg.version,
+        "shared_intrinsics": False,
+        "camera_model": "PINHOLE",
+        "camera_convention": "opencv",
+        "scale_type": "metric",
+        "scene_modalities": {},
+        "frames": frames,
+        "frame_modalities": {
+            "image": {"frame_key": "image", "format": "image"},
+            "depth": {"frame_key": "depth", "format": "depth"},
+        },
+    }
+    store_data(target_scene_root / "scene_meta.json", scene_meta, "scene_meta")
+
+
+def get_original_scene_names(cfg):
+    return _discover_scene_keys(cfg)
+
+
+if __name__ == "__main__":
+    cfg = argconf_parse(WAI_PROC_CONFIG_PATH / "conversion/seven_scenes.yaml")
+    Path(cfg.root).mkdir(parents=True, exist_ok=True)
+    convert_scenes_wrapper(process_seven_scenes_scene, cfg, get_original_scene_names)

--- a/data_processing/wai_processing/scripts/conversion/seven_scenes.py
+++ b/data_processing/wai_processing/scripts/conversion/seven_scenes.py
@@ -27,12 +27,39 @@ CALIB_SUFFIX = ".calibration.txt"
 def _discover_scene_keys(cfg) -> list[str]:
     original_root = Path(cfg.original_root)
     scene_keys: list[str] = []
+    dataset_whitelist_cfg = cfg.get("dataset_whitelist")
+    dataset_whitelist = (
+        {entry.lower() for entry in dataset_whitelist_cfg}
+        if dataset_whitelist_cfg
+        else None
+    )
+    split_whitelist_cfg = cfg.get("split_whitelist")
+    split_whitelist = (
+        {entry.lower() for entry in split_whitelist_cfg}
+        if split_whitelist_cfg
+        else None
+    )
+    sequence_whitelist_cfg = cfg.get("sequence_whitelist")
+    if sequence_whitelist_cfg:
+        sequence_whitelist_full = {entry for entry in sequence_whitelist_cfg}
+        sequence_whitelist_short = {
+            entry.split("/")[-1] for entry in sequence_whitelist_cfg
+        }
+    else:
+        sequence_whitelist_full = set()
+        sequence_whitelist_short = set()
+
     for scene_dir in sorted(original_root.glob("pgt_7scenes_*")):
         if not scene_dir.is_dir():
             continue
         dataset_name = scene_dir.name.replace("pgt_7scenes_", "", 1)
+        if dataset_whitelist and dataset_name.lower() not in dataset_whitelist:
+            continue
         for split_dir in sorted(scene_dir.iterdir()):
             if not split_dir.is_dir():
+                continue
+            split_name = split_dir.name
+            if split_whitelist and split_name.lower() not in split_whitelist:
                 continue
             rgb_dir = split_dir / "rgb"
             if not rgb_dir.exists():
@@ -41,7 +68,12 @@ def _discover_scene_keys(cfg) -> list[str]:
             for image_file in natsorted(rgb_dir.glob(f"*{RGB_SUFFIX}")):
                 prefix = image_file.name.replace(RGB_SUFFIX, "")
                 seq_name = prefix.split("-frame")[0]
-                scene_key = f"{dataset_name}/{split_dir.name}/{seq_name}"
+                scene_key = f"{dataset_name}/{split_name}/{seq_name}"
+                if sequence_whitelist_full and (
+                    scene_key not in sequence_whitelist_full
+                    and seq_name not in sequence_whitelist_short
+                ):
+                    continue
                 if scene_key not in scene_keys:
                     scene_keys.append(scene_key)
     return scene_keys

--- a/data_processing/wai_processing/scripts/conversion/seven_scenes.py
+++ b/data_processing/wai_processing/scripts/conversion/seven_scenes.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import numpy as np
 import torch
 from argconf import argconf_parse
-from mapanything.utils.wai.core import store_data
+from mapanything.utils.wai.core import load_data, store_data
 from natsort import natsorted
 from PIL import Image
 from wai_processing.utils.globals import WAI_PROC_CONFIG_PATH
@@ -65,17 +65,21 @@ def _discover_scene_keys(cfg) -> list[str]:
             if not rgb_dir.exists():
                 logger.warning("Skipping %s; missing rgb/ directory", split_dir)
                 continue
+            has_valid_sequence = False
             for image_file in natsorted(rgb_dir.glob(f"*{RGB_SUFFIX}")):
                 prefix = image_file.name.replace(RGB_SUFFIX, "")
                 seq_name = prefix.split("-frame")[0]
-                scene_key = f"{dataset_name}/{split_name}/{seq_name}"
                 if sequence_whitelist_full and (
-                    scene_key not in sequence_whitelist_full
+                    f"{dataset_name}/{split_name}/{seq_name}" not in sequence_whitelist_full
                     and seq_name not in sequence_whitelist_short
                 ):
                     continue
-                if scene_key not in scene_keys:
-                    scene_keys.append(scene_key)
+                has_valid_sequence = True
+                break
+            if has_valid_sequence:
+                split_key = f"{dataset_name}_{split_name}"
+                if split_key not in scene_keys:
+                    scene_keys.append(split_key)
     return scene_keys
 
 
@@ -122,8 +126,22 @@ def _load_depth(depth_path: Path, invalid_values: set[int]) -> np.ndarray:
     return depth
 
 
+def _sequence_filters(cfg):
+    sequence_whitelist_cfg = cfg.get("sequence_whitelist")
+    if not sequence_whitelist_cfg:
+        return None, None
+    full_keys = {entry for entry in sequence_whitelist_cfg}
+    short_keys = {entry.split("/")[-1] for entry in sequence_whitelist_cfg}
+    return full_keys, short_keys
+
+
 def process_seven_scenes_scene(cfg, scene_key: str):
-    dataset_name, split, sequence = scene_key.split("/")
+    if "_" not in scene_key:
+        raise ValueError(
+            "Expected scene keys to be formatted as '<dataset>_<split>' but received "
+            f"{scene_key!r}."
+        )
+    dataset_name, split = scene_key.split("_", 1)
     source_root = Path(cfg.original_root) / f"pgt_7scenes_{dataset_name}" / split
 
     rgb_dir = source_root / "rgb"
@@ -134,23 +152,47 @@ def process_seven_scenes_scene(cfg, scene_key: str):
     if not rgb_dir.exists():
         raise FileNotFoundError(f"Missing rgb directory at {rgb_dir}")
 
-    wai_scene_name = f"{dataset_name}_{split}_{sequence}"
-    target_scene_root = Path(cfg.root) / wai_scene_name
+    target_scene_root = Path(cfg.root) / scene_key
     image_dir = target_scene_root / "images"
     depth_out_dir = target_scene_root / "depth"
     image_dir.mkdir(parents=True, exist_ok=True)
     depth_out_dir.mkdir(parents=True, exist_ok=True)
 
     invalid_values = set(cfg.get("invalid_depth_values", [0, 65535]))
+    sequence_whitelist_full, sequence_whitelist_short = _sequence_filters(cfg)
 
-    image_files = natsorted(rgb_dir.glob(f"{sequence}-frame-*{RGB_SUFFIX}"))
+    image_files = natsorted(rgb_dir.glob(f"*{RGB_SUFFIX}"))
+    if sequence_whitelist_full or sequence_whitelist_short:
+        filtered_files = []
+        for image_path in image_files:
+            base_name = image_path.name.replace(RGB_SUFFIX, "")
+            seq_name = base_name.split("-frame")[0]
+            if sequence_whitelist_full and (
+                f"{dataset_name}/{split}/{seq_name}" not in sequence_whitelist_full
+                and seq_name not in sequence_whitelist_short
+            ):
+                continue
+            filtered_files.append(image_path)
+        image_files = filtered_files
+
     if not image_files:
         logger.warning("No frames found for %s", scene_key)
-        return "finished", "empty_sequence"
+        return "finished", "empty_split"
 
-    frames = []
+    existing_meta_path = target_scene_root / "scene_meta.json"
+    if existing_meta_path.exists():
+        scene_meta = load_data(existing_meta_path, "scene_meta")
+        frames = list(scene_meta.get("frames", []))
+    else:
+        frames = []
+
+    existing_frame_names = {frame["frame_name"] for frame in frames}
+
     for image_path in image_files:
         base_name = image_path.name.replace(RGB_SUFFIX, "")
+        if base_name in existing_frame_names:
+            continue
+
         depth_path = depth_dir / f"{base_name}{DEPTH_SUFFIX}"
         pose_path = pose_dir / f"{base_name}{POSE_SUFFIX}"
         calib_path = calib_dir / f"{base_name}{CALIB_SUFFIX}"
@@ -163,9 +205,8 @@ def process_seven_scenes_scene(cfg, scene_key: str):
             continue
 
         target_image_path = image_dir / image_path.name
-        if target_image_path.exists():
-            target_image_path.unlink()
-        target_image_path.symlink_to(image_path.resolve())
+        if not target_image_path.exists():
+            target_image_path.symlink_to(image_path.resolve())
 
         depth = _load_depth(depth_path, invalid_values)
         rel_depth_path = Path("depth") / f"{base_name}.exr"
@@ -188,13 +229,16 @@ def process_seven_scenes_scene(cfg, scene_key: str):
             "cy": float(cy),
         }
         frames.append(frame_entry)
+        existing_frame_names.add(base_name)
 
     if not frames:
         logger.warning("All frames skipped for %s", scene_key)
         return "finished", "no_valid_frames"
 
+    frames = sorted(frames, key=lambda frame: frame["frame_name"])
+
     scene_meta = {
-        "scene_name": wai_scene_name,
+        "scene_name": scene_key,
         "dataset_name": cfg.dataset_name,
         "version": cfg.version,
         "shared_intrinsics": False,

--- a/docs/aa_feature_fusion_workflow.md
+++ b/docs/aa_feature_fusion_workflow.md
@@ -19,12 +19,15 @@
 
 1. **运行脚本**：
    ```bash
+   DEVICE=cuda NUM_SAMPLES=4 DATA_ROOT="$WAI_ROOT" \
    bash bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh \
-       [--device cuda] [--num-samples 4] [--indices 0,5,7] [--data-root /path/to/wai_data/7scenes] \
-       /path/to/info_sharing_outputs.pt /tmp/aa_fusion_demo \
+       /path/to/info_sharing_outputs.pt \
+       "$WAI_ROOT/demo_runs" \
        model.pretrained=/path/to/mapanything.ckpt
    ```
-   脚本会自动把存储文件传给 Hydra 配置，输出目录中会生成每个样本对应的 `.pt` 记录与 `summary.json`。【F:bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh†L1-L98】【F:configs/tasks/aa_feature_fusion/demo.yaml†L1-L18】
+   - 如需指定数据索引，可通过 `SAMPLE_INDICES=0,5,7` 覆盖，脚本会自动忽略 `NUM_SAMPLES`。
+   - 额外的 Hydra 覆盖（如 `model.pretrained`、`root_data_dir`）继续以命令行参数形式追加。
+   脚本会自动把存储文件传给 Hydra 配置，输出目录中会生成每个样本对应的 `.pt` 记录与 `summary.json`。【F:bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh†L1-L55】【F:configs/tasks/aa_feature_fusion/demo.yaml†L1-L18】
 2. **内部流程**：Demo 入口会加载 7Scenes 测试集的单视图样本，按配置取用内参/深度/位姿信息，然后通过融合模块与 MapAnything 的下游头部恢复点云或深度图，并序列化到磁盘。【F:mapanything/tasks/aa_feature_fusion/demo.py†L17-L137】【F:mapanything/tasks/aa_feature_fusion/demo.py†L139-L207】
 3. **可视化**：在 WSL 或本地机器执行 `python scripts/visualization/view_aa_fusion_demo.py sample.pt --save sample.png --export-pts sample.ply` 即可预览 RGB 与重建深度，并可选导出 PLY 点云。【F:scripts/visualization/view_aa_fusion_demo.py†L1-L96】
 

--- a/docs/aa_feature_fusion_workflow.md
+++ b/docs/aa_feature_fusion_workflow.md
@@ -21,9 +21,10 @@
    ```bash
    bash bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh \
        [--device cuda] [--num-samples 4] [--indices 0,5,7] [--data-root /path/to/wai_data/7scenes] \
-       <conda_env> <path/to/info_sharing_outputs.pt> <output_dir>
+       /path/to/info_sharing_outputs.pt /tmp/aa_fusion_demo \
+       model.pretrained=/path/to/mapanything.ckpt
    ```
-   脚本会自动把存储文件传给 Hydra 配置，输出目录中会生成每个样本对应的 `.pt` 记录与 `summary.json`。【F:bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh†L1-L86】【F:configs/tasks/aa_feature_fusion/demo.yaml†L1-L18】
+   脚本会自动把存储文件传给 Hydra 配置，输出目录中会生成每个样本对应的 `.pt` 记录与 `summary.json`。【F:bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh†L1-L98】【F:configs/tasks/aa_feature_fusion/demo.yaml†L1-L18】
 2. **内部流程**：Demo 入口会加载 7Scenes 测试集的单视图样本，按配置取用内参/深度/位姿信息，然后通过融合模块与 MapAnything 的下游头部恢复点云或深度图，并序列化到磁盘。【F:mapanything/tasks/aa_feature_fusion/demo.py†L17-L137】【F:mapanything/tasks/aa_feature_fusion/demo.py†L139-L207】
 3. **可视化**：在 WSL 或本地机器执行 `python scripts/visualization/view_aa_fusion_demo.py sample.pt --save sample.png --export-pts sample.ply` 即可预览 RGB 与重建深度，并可选导出 PLY 点云。【F:scripts/visualization/view_aa_fusion_demo.py†L1-L96】
 

--- a/docs/aa_feature_fusion_workflow.md
+++ b/docs/aa_feature_fusion_workflow.md
@@ -19,15 +19,15 @@
 
 1. **运行脚本**：
    ```bash
+   STORED_FEATURE_FILE=/path/to/info_sharing_outputs.pt \
+   OUTPUT_ROOT="$WAI_ROOT/demo_runs" \
    DEVICE=cuda NUM_SAMPLES=4 DATA_ROOT="$WAI_ROOT" \
-   bash bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh \
-       /path/to/info_sharing_outputs.pt \
-       "$WAI_ROOT/demo_runs" \
-       model.pretrained=/path/to/mapanything.ckpt
+   HYDRA_OVERRIDES="model.pretrained=/path/to/mapanything.ckpt" \
+   bash bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh
    ```
    - 如需指定数据索引，可通过 `SAMPLE_INDICES=0,5,7` 覆盖，脚本会自动忽略 `NUM_SAMPLES`。
-   - 额外的 Hydra 覆盖（如 `model.pretrained`、`root_data_dir`）继续以命令行参数形式追加。
-   脚本会自动把存储文件传给 Hydra 配置，输出目录中会生成每个样本对应的 `.pt` 记录与 `summary.json`。【F:bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh†L1-L55】【F:configs/tasks/aa_feature_fusion/demo.yaml†L1-L18】
+   - 额外的 Hydra 覆盖（如 `model.pretrained`、`root_data_dir`）可在 `HYDRA_OVERRIDES` 中以空格分隔追加。
+   脚本会自动把存储文件传给 Hydra 配置，输出目录中会生成每个样本对应的 `.pt` 记录与 `summary.json`。【F:bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh†L1-L63】【F:configs/tasks/aa_feature_fusion/demo.yaml†L1-L18】
 2. **内部流程**：Demo 入口会加载 7Scenes 测试集的单视图样本，按配置取用内参/深度/位姿信息，然后通过融合模块与 MapAnything 的下游头部恢复点云或深度图，并序列化到磁盘。【F:mapanything/tasks/aa_feature_fusion/demo.py†L17-L137】【F:mapanything/tasks/aa_feature_fusion/demo.py†L139-L207】
 3. **可视化**：在 WSL 或本地机器执行 `python scripts/visualization/view_aa_fusion_demo.py sample.pt --save sample.png --export-pts sample.ply` 即可预览 RGB 与重建深度，并可选导出 PLY 点云。【F:scripts/visualization/view_aa_fusion_demo.py†L1-L96】
 

--- a/docs/aa_feature_fusion_workflow.md
+++ b/docs/aa_feature_fusion_workflow.md
@@ -1,0 +1,46 @@
+# 7Scenes 交替注意力特征融合功能介绍
+
+本文汇总了仓库中新加入的交替注意力（Alternating-Attention，AA）特征融合组件、配置与脚本，帮助你从捕获多视图记忆、到单视图重建 Demo、再到后续训练/评估任务的完整流程。
+
+## 功能总览
+
+- **特征记忆载入与复原**：`StoredAAFeatureSequence` 可以直接从 `info_sharing_outputs.pt` 中重建 AA 块的特征序列（含附加 token 与空间尺寸），供后续注意力模块复用。【F:mapanything/tasks/aa_feature_fusion/fusion.py†L41-L141】
+- **单视图-多记忆融合模块**：`AAFeatureFusionModule` 将单视图编码后的 token 作为查询，仅对其执行帧内注意力，并把存储的多视图记忆作为全局注意力的键值，实现查询与记忆的交互。【F:mapanything/tasks/aa_feature_fusion/fusion.py†L143-L274】
+- **流水线封装**：`AAFeatureFusionPipeline` 负责根据配置筛选单视图模态、抽取编码 token，并调用融合模块输出可被下游头部消费的特征图。【F:mapanything/tasks/aa_feature_fusion/pipeline.py†L12-L53】
+- **可复用的构建入口**：`build_pipeline_from_cfg` 将 Hydra 配置映射为 MapAnything 主干模型与 AA 融合模块，方便训练、评估与 Demo 共用同一套组件。【F:mapanything/tasks/aa_feature_fusion/builder.py†L12-L32】
+
+## 数据与存储准备
+
+1. **转换 7Scenes 数据为 WAI 布局**：按照《7Scenes WAI 数据流水线指南》下载原始数据、伪真值，并调用 `seven_scenes_to_wai.sh` 生成 `wai_data/7scenes` 目录。【F:docs/seven_scenes_wai_pipeline.md†L1-L22】【F:bash_scripts/data_processing/seven_scenes_to_wai.sh†L1-L156】
+2. **捕获多视图 AA 中间变量**：使用 `ace_store_intermediates.sh`（或 `mapa_24v_store_intermediates.sh`）在 7Scenes 上运行 MapAnything 推理，将所有 AA 块写入单个 `info_sharing_outputs.pt` 文件。【F:bash_scripts/ace/ace_store_intermediates.sh†L1-L78】
+3. **准备单视图输入配置**：`configs/model/task/single_view_optional_intrinsics.yaml` 仅保留图像与可选内参，避免在融合阶段重复加载多余的几何信号。【F:configs/model/task/single_view_optional_intrinsics.yaml†L1-L18】
+
+## Demo：单视图重建示例
+
+1. **运行脚本**：
+   ```bash
+   bash bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh \
+       [--device cuda] [--num-samples 4] [--indices 0,5,7] [--data-root /path/to/wai_data/7scenes] \
+       <conda_env> <path/to/info_sharing_outputs.pt> <output_dir>
+   ```
+   脚本会自动把存储文件传给 Hydra 配置，输出目录中会生成每个样本对应的 `.pt` 记录与 `summary.json`。【F:bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh†L1-L86】【F:configs/tasks/aa_feature_fusion/demo.yaml†L1-L18】
+2. **内部流程**：Demo 入口会加载 7Scenes 测试集的单视图样本，按配置取用内参/深度/位姿信息，然后通过融合模块与 MapAnything 的下游头部恢复点云或深度图，并序列化到磁盘。【F:mapanything/tasks/aa_feature_fusion/demo.py†L17-L137】【F:mapanything/tasks/aa_feature_fusion/demo.py†L139-L207】
+3. **可视化**：在 WSL 或本地机器执行 `python scripts/visualization/view_aa_fusion_demo.py sample.pt --save sample.png --export-pts sample.ply` 即可预览 RGB 与重建深度，并可选导出 PLY 点云。【F:scripts/visualization/view_aa_fusion_demo.py†L1-L96】
+
+## 训练与评估脚手架
+
+- **训练入口**：`python -m mapanything.tasks.aa_feature_fusion.train fusion.stored_feature_file=/path/to/info_sharing_outputs.pt` 将构建流水线并打印占位训练信息，后续可在 `run_training` 中补全优化逻辑。【F:mapanything/tasks/aa_feature_fusion/train.py†L1-L36】【F:configs/tasks/aa_feature_fusion/train.yaml†L1-L19】
+- **评估入口**：`python -m mapanything.tasks.aa_feature_fusion.eval fusion.stored_feature_file=/path/to/info_sharing_outputs.pt` 会按照 `test.yaml` 载入数据与流水线，为日后集成指标计算留出接口。【F:mapanything/tasks/aa_feature_fusion/eval.py†L1-L39】【F:configs/tasks/aa_feature_fusion/test.yaml†L1-L11】
+- **共享默认配置**：`configs/tasks/aa_feature_fusion/default.yaml` 统一描述模型、数据集与融合参数，可通过命令行覆盖 `fusion.map_location`、`single_view.include_depth` 等字段进行实验扩展。【F:configs/tasks/aa_feature_fusion/default.yaml†L1-L23】
+
+## 输出结构与后续处理
+
+Demo 生成的 `.pt` 文件包含：
+
+- 原始单视图 RGB、内参与相机位姿。
+- 融合后经 MapAnything 头部推理出的点云、深度或其他场景表示，字段名称与 `scene_rep_type` 相匹配。
+- 用于追踪样本来源的 `dataset`、`label` 与 `instance` 元数据。
+
+这些字段对应 Demo 中写入磁盘的 `record` 字典，可直接在自定义脚本中读取并接入新的任务管线。【F:mapanything/tasks/aa_feature_fusion/demo.py†L172-L205】
+
+通过以上文档与脚本，你可以在不改动核心模型的前提下，完成 7Scenes 上的 AA 特征捕获、单视图融合重建，以及后续训练评估的搭建，为扩展任务奠定基础。

--- a/docs/mapanything_aa_feature_storage.md
+++ b/docs/mapanything_aa_feature_storage.md
@@ -1,35 +1,35 @@
-# MapAnything alternating-attention feature storage
+# MapAnything 交替注意力特征存储指南
 
-This document explains how the MapAnything model captures, stores, and reloads the alternating-attention (AA) transformer features that are produced during inference. It summarises the configuration knobs you enable through Hydra and walks through the runtime helpers that package the tensors in-memory or on disk.
+本文详细说明 MapAnything 模型在推理阶段如何捕获、存储以及重新加载交替注意力（Alternating-Attention，AA）Transformer 产生的特征。你将看到需要开启的 Hydra 配置、运行期负责打包张量的辅助函数，以及它们在内存与磁盘之间切换时的具体行为。
 
-## Enabling capture through configuration
+## 通过配置开启特征捕获
 
-Hydra presets such as [`configs/model/mapanything_store_intermediates.yaml`](../configs/model/mapanything_store_intermediates.yaml) and [`configs/model/mapanything_store_intermediates_ace.yaml`](../configs/model/mapanything_store_intermediates_ace.yaml) set the `model_config.store_info_sharing_intermediate_features` flag to `true` and provide a storage location via `model_config.info_sharing_storage_path`.【F:configs/model/mapanything_store_intermediates.yaml†L12-L22】【F:configs/model/mapanything_store_intermediates_ace.yaml†L12-L22】 When a run directory is supplied, the model writes a single `info_sharing_outputs.pt` payload per inference into the `${hydra:run.dir}` tree (for example, `${hydra:run.dir}/aa_features` or `${hydra:run.dir}/ACE/aa_blocks`).
+Hydra 预设（例如 [`configs/model/mapanything_store_intermediates.yaml`](../configs/model/mapanything_store_intermediates.yaml) 与 [`configs/model/mapanything_store_intermediates_ace.yaml`](../configs/model/mapanything_store_intermediates_ace.yaml)）会把 `model_config.store_info_sharing_intermediate_features` 设为 `true`，同时通过 `model_config.info_sharing_storage_path` 指定存储位置。【F:configs/model/mapanything_store_intermediates.yaml†L12-L22】【F:configs/model/mapanything_store_intermediates_ace.yaml†L12-L22】如果配置了运行目录，模型会在 `${hydra:run.dir}` 下写出单个 `info_sharing_outputs.pt` 文件（例如 `${hydra:run.dir}/aa_features` 或 `${hydra:run.dir}/ACE/aa_blocks`）。
 
-If you omit the storage path, the same flag keeps the features in memory on an optional target device controlled by `model_config.info_sharing_storage_device` before returning them to the caller.【F:mapanything/models/mapanything/model.py†L140-L172】 This lets you prototype without touching disk.
+若未提供存储路径，同一开关会把特征保存在内存中，并根据 `model_config.info_sharing_storage_device` 决定目标设备，然后再把特征返回给调用方。【F:mapanything/models/mapanything/model.py†L140-L172】这让你可以在不落盘的情况下完成调试。
 
-## Forward pass capture flow
+## Forward 流程中的捕获逻辑
 
-During the standard `forward` method, the model optionally receives the intermediate transformer outputs alongside the final alternating-attention result when `info_sharing_return_type` requests them.【F:mapanything/models/mapanything/model.py†L1568-L1587】 Once the transformer call returns, the flag described above decides whether `_capture_info_sharing_features` is invoked to record the tensors.【F:mapanything/models/mapanything/model.py†L1589-L1594】 Disabling the flag clears any previously cached outputs.【F:mapanything/models/mapanything/model.py†L1595-L1596】
+在标准的 `forward` 方法里，只要 `info_sharing_return_type` 请求返回中间 AA 结果，模型就会在最终输出之外额外拿到 Transformer 的中间块。【F:mapanything/models/mapanything/model.py†L1568-L1587】Transformer 调用结束后，前面的开关会决定是否调用 `_capture_info_sharing_features` 来记录这些张量。【F:mapanything/models/mapanything/model.py†L1589-L1594】如果不开启，该方法会清理此前缓存的输出，避免复用过期数据。【F:mapanything/models/mapanything/model.py†L1595-L1596】
 
-`_capture_info_sharing_features` creates the metadata that you later retrieve by calling `get_info_sharing_intermediate_features`. Internally it branches on whether a run directory was provisioned:
+`_capture_info_sharing_features` 会构造后续通过 `get_info_sharing_intermediate_features` 取出的元数据，内部根据是否配置了磁盘路径分成两种模式：
 
-* **Memory mode:** When no `info_sharing_storage_path` is configured, each `MultiViewTransformerOutput` is cloned (and optionally moved to `info_sharing_storage_device`) through `_serialize_multi_view_output`, preserving both view-wise features and additional token embeddings.【F:mapanything/models/mapanything/model.py†L1976-L2010】 The returned dictionary includes the `storage_mode="memory"` marker together with the cloned outputs.【F:mapanything/models/mapanything/model.py†L2058-L2079】
-* **Disk mode:** When a storage path is present, `_create_info_sharing_run_directory` materialises a timestamped subdirectory under the configured root.【F:mapanything/models/mapanything/model.py†L2032-L2056】 `_prepare_output_for_disk` then detaches each tensor to CPU, tags every block, and assembles a serialisable dictionary before `_write_info_sharing_payload` saves everything to `info_sharing_outputs.pt`.【F:mapanything/models/mapanything/model.py†L2012-L2031】【F:mapanything/models/mapanything/model.py†L2079-L2099】 Alongside the on-disk file, the method returns lightweight metadata (shapes, block indices, and tags) so callers can inspect what was captured without reloading the tensors.【F:mapanything/models/mapanything/model.py†L2024-L2031】【F:mapanything/models/mapanything/model.py†L2099-L2110】
+* **内存模式：** 当 `info_sharing_storage_path` 为空时，`_serialize_multi_view_output` 会克隆每个 `MultiViewTransformerOutput`（必要时迁移到 `info_sharing_storage_device`），保留各视角特征以及额外 token 的嵌入。【F:mapanything/models/mapanything/model.py†L1976-L2010】返回的字典会带上 `storage_mode="memory"` 标记和克隆后的输出。【F:mapanything/models/mapanything/model.py†L2058-L2079】
+* **磁盘模式：** 当存在存储路径时，`_create_info_sharing_run_directory` 会在配置目录下创建一个带时间戳的子目录。【F:mapanything/models/mapanything/model.py†L2032-L2056】随后 `_prepare_output_for_disk` 会把每个张量转到 CPU、标记每个 AA 块，再由 `_write_info_sharing_payload` 将整理好的字典写入 `info_sharing_outputs.pt`。【F:mapanything/models/mapanything/model.py†L2012-L2031】【F:mapanything/models/mapanything/model.py†L2079-L2099】与此同时，函数会返回轻量级元数据（形状、块索引、标签），便于调用方无需加载文件即可了解捕获内容。【F:mapanything/models/mapanything/model.py†L2024-L2031】【F:mapanything/models/mapanything/model.py†L2099-L2110】
 
-In both modes the stored payload records the transformer's `return_type`, `info_sharing_type`, the final AA block, and every intermediate AA block in order, ensuring downstream consumers can reconstruct the complete attention stack.【F:mapanything/models/mapanything/model.py†L2079-L2094】
+无论哪种模式，存储的 payload 都会记录 Transformer 的 `return_type`、`info_sharing_type`、最终 AA 块以及所有中间 AA 块，确保下游使用者能完整还原注意力堆栈。【F:mapanything/models/mapanything/model.py†L2079-L2094】
 
-## Retrieving the cached tensors
+## 取回缓存张量
 
-`get_info_sharing_intermediate_features` simply hands back the cached dictionary and optionally clears it so the next forward call does not reuse stale tensors.【F:mapanything/models/mapanything/model.py†L2118-L2129】 The schema mirrors what `_capture_info_sharing_features` produced, meaning callers see either the in-memory `MultiViewTransformerOutput` objects or the disk metadata described above.
+`get_info_sharing_intermediate_features` 直接返回缓存字典，并可选择性地清空，避免下一次 forward 复用旧数据。【F:mapanything/models/mapanything/model.py†L2118-L2129】返回的结构与 `_capture_info_sharing_features` 生成的格式一致：若为内存模式，即得到 `MultiViewTransformerOutput` 对象；若为磁盘模式，则只含元数据。
 
-When you later want to inspect a saved run, `load_info_sharing_features_from_file` accepts the `info_sharing_outputs.pt` path, runs `torch.load`, and recreates the final and intermediate transformer blocks as fresh `MultiViewTransformerOutput` instances (unless you request the raw dictionary).【F:mapanything/models/mapanything/model.py†L2134-L2176】 This helper hides the on-disk layout and centralises all deserialisation logic.
+需要离线分析时，可调用 `load_info_sharing_features_from_file` 读取 `info_sharing_outputs.pt`。该函数会执行 `torch.load`，重新构造最终与中间 Transformer 块的 `MultiViewTransformerOutput` 实例（除非显式请求返回原始字典）。【F:mapanything/models/mapanything/model.py†L2134-L2176】这样可以把反序列化逻辑集中在一个地方。
 
-## Summary of the capture lifecycle
+## 工作流回顾
 
-1. Enable `store_info_sharing_intermediate_features` and optionally choose a disk path through the Hydra configuration.
-2. Run inference. The `forward` method records the alternating-attention outputs by invoking `_capture_info_sharing_features`.
-3. Inspect the metadata returned by `get_info_sharing_intermediate_features` (memory mode) or reference the saved `info_sharing_outputs.pt` file (disk mode).
-4. Rehydrate the tensors later with `load_info_sharing_features_from_file` when you need to analyse or visualise the alternating-attention blocks offline.
+1. 在 Hydra 配置中开启 `store_info_sharing_intermediate_features`，并按需设定 `info_sharing_storage_path`。
+2. 运行推理；`forward` 会调用 `_capture_info_sharing_features` 保存交替注意力输出。
+3. 通过 `get_info_sharing_intermediate_features` 立即查看内存模式的结果，或在磁盘模式下定位 `info_sharing_outputs.pt`。
+4. 当需要离线分析或可视化时，使用 `load_info_sharing_features_from_file` 重新加载 AA 块。
 
-These utilities let you treat intermediate transformer activations as first-class artefacts without modifying the rest of the inference pipeline.
+借助这些工具，你可以在不修改其他推理流程的情况下，把 Transformer 的中间激活当作一等公民来管理。

--- a/docs/mapanything_aa_feature_storage.md
+++ b/docs/mapanything_aa_feature_storage.md
@@ -1,0 +1,35 @@
+# MapAnything alternating-attention feature storage
+
+This document explains how the MapAnything model captures, stores, and reloads the alternating-attention (AA) transformer features that are produced during inference. It summarises the configuration knobs you enable through Hydra and walks through the runtime helpers that package the tensors in-memory or on disk.
+
+## Enabling capture through configuration
+
+Hydra presets such as [`configs/model/mapanything_store_intermediates.yaml`](../configs/model/mapanything_store_intermediates.yaml) and [`configs/model/mapanything_store_intermediates_ace.yaml`](../configs/model/mapanything_store_intermediates_ace.yaml) set the `model_config.store_info_sharing_intermediate_features` flag to `true` and provide a storage location via `model_config.info_sharing_storage_path`.【F:configs/model/mapanything_store_intermediates.yaml†L12-L22】【F:configs/model/mapanything_store_intermediates_ace.yaml†L12-L22】 When a run directory is supplied, the model writes a single `info_sharing_outputs.pt` payload per inference into the `${hydra:run.dir}` tree (for example, `${hydra:run.dir}/aa_features` or `${hydra:run.dir}/ACE/aa_blocks`).
+
+If you omit the storage path, the same flag keeps the features in memory on an optional target device controlled by `model_config.info_sharing_storage_device` before returning them to the caller.【F:mapanything/models/mapanything/model.py†L140-L172】 This lets you prototype without touching disk.
+
+## Forward pass capture flow
+
+During the standard `forward` method, the model optionally receives the intermediate transformer outputs alongside the final alternating-attention result when `info_sharing_return_type` requests them.【F:mapanything/models/mapanything/model.py†L1568-L1587】 Once the transformer call returns, the flag described above decides whether `_capture_info_sharing_features` is invoked to record the tensors.【F:mapanything/models/mapanything/model.py†L1589-L1594】 Disabling the flag clears any previously cached outputs.【F:mapanything/models/mapanything/model.py†L1595-L1596】
+
+`_capture_info_sharing_features` creates the metadata that you later retrieve by calling `get_info_sharing_intermediate_features`. Internally it branches on whether a run directory was provisioned:
+
+* **Memory mode:** When no `info_sharing_storage_path` is configured, each `MultiViewTransformerOutput` is cloned (and optionally moved to `info_sharing_storage_device`) through `_serialize_multi_view_output`, preserving both view-wise features and additional token embeddings.【F:mapanything/models/mapanything/model.py†L1976-L2010】 The returned dictionary includes the `storage_mode="memory"` marker together with the cloned outputs.【F:mapanything/models/mapanything/model.py†L2058-L2079】
+* **Disk mode:** When a storage path is present, `_create_info_sharing_run_directory` materialises a timestamped subdirectory under the configured root.【F:mapanything/models/mapanything/model.py†L2032-L2056】 `_prepare_output_for_disk` then detaches each tensor to CPU, tags every block, and assembles a serialisable dictionary before `_write_info_sharing_payload` saves everything to `info_sharing_outputs.pt`.【F:mapanything/models/mapanything/model.py†L2012-L2031】【F:mapanything/models/mapanything/model.py†L2079-L2099】 Alongside the on-disk file, the method returns lightweight metadata (shapes, block indices, and tags) so callers can inspect what was captured without reloading the tensors.【F:mapanything/models/mapanything/model.py†L2024-L2031】【F:mapanything/models/mapanything/model.py†L2099-L2110】
+
+In both modes the stored payload records the transformer's `return_type`, `info_sharing_type`, the final AA block, and every intermediate AA block in order, ensuring downstream consumers can reconstruct the complete attention stack.【F:mapanything/models/mapanything/model.py†L2079-L2094】
+
+## Retrieving the cached tensors
+
+`get_info_sharing_intermediate_features` simply hands back the cached dictionary and optionally clears it so the next forward call does not reuse stale tensors.【F:mapanything/models/mapanything/model.py†L2118-L2129】 The schema mirrors what `_capture_info_sharing_features` produced, meaning callers see either the in-memory `MultiViewTransformerOutput` objects or the disk metadata described above.
+
+When you later want to inspect a saved run, `load_info_sharing_features_from_file` accepts the `info_sharing_outputs.pt` path, runs `torch.load`, and recreates the final and intermediate transformer blocks as fresh `MultiViewTransformerOutput` instances (unless you request the raw dictionary).【F:mapanything/models/mapanything/model.py†L2134-L2176】 This helper hides the on-disk layout and centralises all deserialisation logic.
+
+## Summary of the capture lifecycle
+
+1. Enable `store_info_sharing_intermediate_features` and optionally choose a disk path through the Hydra configuration.
+2. Run inference. The `forward` method records the alternating-attention outputs by invoking `_capture_info_sharing_features`.
+3. Inspect the metadata returned by `get_info_sharing_intermediate_features` (memory mode) or reference the saved `info_sharing_outputs.pt` file (disk mode).
+4. Rehydrate the tensors later with `load_info_sharing_features_from_file` when you need to analyse or visualise the alternating-attention blocks offline.
+
+These utilities let you treat intermediate transformer activations as first-class artefacts without modifying the rest of the inference pipeline.

--- a/docs/mapanything_aa_feature_storage_deep_dive.md
+++ b/docs/mapanything_aa_feature_storage_deep_dive.md
@@ -1,0 +1,135 @@
+# MapAnything alternating-attention capture walkthrough
+
+This deep-dive accompanies the high-level overview in
+[`docs/mapanything_aa_feature_storage.md`](./mapanything_aa_feature_storage.md) by
+explaining the exact code paths that persist alternating-attention (AA)
+intermediates inside `mapanything/models/mapanything/model.py`. Every section
+below highlights the responsible helper, the relevant arguments, and any
+non-obvious implementation details so you can adapt or extend the
+functionality with confidence.
+
+## Entry point: `forward`
+
+The capture workflow begins inside
+[`MapAnythingModel.forward`](../mapanything/models/mapanything/model.py). After
+computing the dense encoder features and invoking the multi-view transformer,
+the method decides whether to stash the AA outputs by checking the
+`store_info_sharing_intermediate_features` flag. When the flag is enabled, the
+final transformer result (`MultiViewTransformerOutput`) and the optional list of
+intermediate blocks are passed to `_capture_info_sharing_features` and the
+returned payload is cached on `self._stored_info_sharing_features`. If the flag
+is disabled the cache is cleared so stale tensors are never exposed to callers.
+
+Key lines:
+
+* `final_info_sharing_multi_view_feat` and
+  `intermediate_info_sharing_multi_view_feat` are populated based on
+  `info_sharing_return_type`.
+* `_capture_info_sharing_features` receives both outputs and converts them to a
+  serialisable structure when storage is requested.
+* The result is retained until `get_info_sharing_intermediate_features` is
+  called or the next forward pass overwrites it.
+
+## Selecting the storage backend: `_capture_info_sharing_features`
+
+`_capture_info_sharing_features(final_output, intermediate_outputs)` is the
+central branching helper. Its job is to determine whether the tensors should be
+kept in memory or written to disk. The decision hinges on
+`self.info_sharing_storage_path`:
+
+* **Memory mode** (no storage path): `_serialize_multi_view_output` clones each
+  `MultiViewTransformerOutput` to avoid side effects, optionally moves the clone
+  to `info_sharing_storage_device`, and assembles a dictionary containing the
+  transformer metadata plus the cloned outputs. The method tags the dictionary
+  with `storage_mode="memory"` so downstream code can reason about the payload
+  without inspecting the tensors.
+* **Disk mode** (storage path provided): `_create_info_sharing_run_directory`
+  builds a fresh run directory under `info_sharing_storage_path`, then
+  `_prepare_output_for_disk` converts every AA block into a plain dictionary with
+  CPU tensors and descriptive tags. The helper aggregates the final and
+  intermediate blocks into a `payload` dictionary, forwards it to
+  `_write_info_sharing_payload`, and finally returns lightweight metadata about
+  what was saved (paths, shapes, block indices) alongside
+  `storage_mode="disk"`.
+
+Regardless of the storage mode, the method captures the transformer
+`return_type` and `info_sharing_type` so consumers can reconstruct the exact
+inference configuration later on.
+
+## Converting AA blocks: `_serialize_multi_view_output`
+
+This helper is only used in memory mode. It receives a
+`MultiViewTransformerOutput`, clones the `features` tensor as well as the
+optional `additional_token_features`, and records the tensor shapes. If
+`self.info_sharing_storage_device` is set, the clones are moved to that device
+(e.g. CPU for long-lived storage). The returned dictionary mirrors the input
+structure:
+
+```python
+{
+    "features": cloned_features,
+    "additional_token_features": cloned_additional_tokens,
+    "shape": tuple(cloned_features.shape),
+}
+```
+
+Cloning is crucial: it ensures that subsequent layers cannot mutate the stored
+activations and that the underlying storage device can be changed without
+impacting the original forward pass tensors.
+
+## Preparing disk payloads
+
+When a storage directory is configured, three helpers participate in writing the
+payload to disk:
+
+1. **`_create_info_sharing_run_directory`** resolves the base path, generates a
+   timestamped run directory (e.g. `2024-05-05T12-34-56`), creates it on disk,
+   and returns the `Path` object. It also removes any stale directory when the
+   flag is disabled to avoid mixing runs.
+2. **`_prepare_output_for_disk`** receives either the final transformer output or
+   a single intermediate block plus a tag (`"final"` or `"intermediate"`) and an
+   optional index. It moves tensors to CPU, detaches them, and packages them in a
+   dictionary with fields such as `block_type`, `block_index`, `features`, and
+   `additional_token_features`.
+3. **`_write_info_sharing_payload`** materialises the `payload` file. It uses
+   `torch.save` to serialize the dictionary to `info_sharing_outputs.pt` inside
+   the run directory. The function returns the final `Path` to aid logging and
+   later inspection.
+
+Combining these helpers ensures that every AA block (final and intermediate) is
+preserved in a single file along with rich metadata.
+
+## Accessing cached results: `get_info_sharing_intermediate_features`
+
+After `_capture_info_sharing_features` executes, the forward pass can expose the
+stored payload through `get_info_sharing_intermediate_features(clear=False)`. In
+memory mode the method returns the cloned `MultiViewTransformerOutput`
+instances, while disk mode returns the metadata describing the on-disk file. The
+optional `clear` flag erases the cached result, which is helpful when repeatedly
+calling `forward` in the same Python session.
+
+## Reloading from disk: `load_info_sharing_features_from_file`
+
+To rehydrate a saved run, call
+`load_info_sharing_features_from_file(path, map_location=None, as_outputs=True)`.
+The helper expands the provided `path`, loads the serialized dictionary via
+`torch.load`, and—when `as_outputs` is `True`—wraps each block back into a new
+`MultiViewTransformerOutput`. Returning raw dictionaries is also supported by
+setting `as_outputs=False`, which can be useful for custom tooling or
+non-PyTorch inspection pipelines.
+
+## Putting it together
+
+1. Enable capture through the Hydra configuration by setting
+   `store_info_sharing_intermediate_features=true` and optionally supplying
+   `info_sharing_storage_path`.
+2. Run inference. The `forward` method saves the transformer outputs using the
+   helper chain described above.
+3. Retrieve the results immediately with
+   `get_info_sharing_intermediate_features` or later by loading the
+   `info_sharing_outputs.pt` artifact with
+   `load_info_sharing_features_from_file`.
+
+By following these steps you can treat alternating-attention intermediates as a
+first-class artifact, adapt the storage pipeline, or integrate the saved tensors
+into downstream ACE tasks without revisiting the implementation.

--- a/docs/mapanything_aa_feature_storage_deep_dive.md
+++ b/docs/mapanything_aa_feature_storage_deep_dive.md
@@ -1,69 +1,36 @@
-# MapAnything alternating-attention capture walkthrough
+# MapAnything 交替注意力捕获全流程解析
 
-This deep-dive accompanies the high-level overview in
-[`docs/mapanything_aa_feature_storage.md`](./mapanything_aa_feature_storage.md) by
-explaining the exact code paths that persist alternating-attention (AA)
-intermediates inside `mapanything/models/mapanything/model.py`. Every section
-below highlights the responsible helper, the relevant arguments, and any
-non-obvious implementation details so you can adapt or extend the
-functionality with confidence.
+本深度解析与概览文档 [`docs/mapanything_aa_feature_storage.md`](./mapanything_aa_feature_storage.md) 配套，逐段说明 `mapanything/models/mapanything/model.py` 中负责持久化交替注意力（AA）中间结果的代码路径。每一节都会指出涉及的辅助函数、入参以及关键实现细节，方便你在理解后进行扩展或定制。
 
-## Entry point: `forward`
+## 入口：`forward`
 
-The capture workflow begins inside
-[`MapAnythingModel.forward`](../mapanything/models/mapanything/model.py). After
-computing the dense encoder features and invoking the multi-view transformer,
-the method decides whether to stash the AA outputs by checking the
-`store_info_sharing_intermediate_features` flag. When the flag is enabled, the
-final transformer result (`MultiViewTransformerOutput`) and the optional list of
-intermediate blocks are passed to `_capture_info_sharing_features` and the
-returned payload is cached on `self._stored_info_sharing_features`. If the flag
-is disabled the cache is cleared so stale tensors are never exposed to callers.
+工作流始于 [`MapAnythingModel.forward`](../mapanything/models/mapanything/model.py)。在完成稠密编码特征并调用多视角 Transformer 之后，函数会检查 `store_info_sharing_intermediate_features` 是否开启：
 
-Key lines:
+* 如果启用，该方法会把最终的 `MultiViewTransformerOutput` 以及可选的中间块列表传递给 `_capture_info_sharing_features`，并把返回的 payload 缓存在 `self._stored_info_sharing_features`。
+* 如果未启用，则立即清空缓存，确保不会向调用方暴露过期张量。
 
-* `final_info_sharing_multi_view_feat` and
-  `intermediate_info_sharing_multi_view_feat` are populated based on
-  `info_sharing_return_type`.
-* `_capture_info_sharing_features` receives both outputs and converts them to a
-  serialisable structure when storage is requested.
-* The result is retained until `get_info_sharing_intermediate_features` is
-  called or the next forward pass overwrites it.
+关键代码要点：
 
-## Selecting the storage backend: `_capture_info_sharing_features`
+* `final_info_sharing_multi_view_feat` 与 `intermediate_info_sharing_multi_view_feat` 会根据 `info_sharing_return_type` 是否请求中间输出来填充。
+* `_capture_info_sharing_features` 接收两类输出，并在需要存储时把它们转换成可序列化的结构。
+* 该结果会一直保留，直到调用 `get_info_sharing_intermediate_features` 或下一次 forward 覆盖它。
 
-`_capture_info_sharing_features(final_output, intermediate_outputs)` is the
-central branching helper. Its job is to determine whether the tensors should be
-kept in memory or written to disk. The decision hinges on
-`self.info_sharing_storage_path`:
+## 选择存储后端：`_capture_info_sharing_features`
 
-* **Memory mode** (no storage path): `_serialize_multi_view_output` clones each
-  `MultiViewTransformerOutput` to avoid side effects, optionally moves the clone
-  to `info_sharing_storage_device`, and assembles a dictionary containing the
-  transformer metadata plus the cloned outputs. The method tags the dictionary
-  with `storage_mode="memory"` so downstream code can reason about the payload
-  without inspecting the tensors.
-* **Disk mode** (storage path provided): `_create_info_sharing_run_directory`
-  builds a fresh run directory under `info_sharing_storage_path`, then
-  `_prepare_output_for_disk` converts every AA block into a plain dictionary with
-  CPU tensors and descriptive tags. The helper aggregates the final and
-  intermediate blocks into a `payload` dictionary, forwards it to
-  `_write_info_sharing_payload`, and finally returns lightweight metadata about
-  what was saved (paths, shapes, block indices) alongside
-  `storage_mode="disk"`.
+`_capture_info_sharing_features(final_output, intermediate_outputs)` 是整个链路的核心分流函数，负责决定张量应保存在内存还是写入磁盘。判断依据是 `self.info_sharing_storage_path`：
 
-Regardless of the storage mode, the method captures the transformer
-`return_type` and `info_sharing_type` so consumers can reconstruct the exact
-inference configuration later on.
+* **内存模式（未配置存储路径）**：`_serialize_multi_view_output` 会克隆每个 `MultiViewTransformerOutput`，以避免后续修改原始张量。若设置了 `info_sharing_storage_device`，克隆体会被迁移到指定设备（常见于将数据移至 CPU 便于长时间保留）。函数随后构造包含 Transformer 元数据与克隆张量的字典，并标记 `storage_mode="memory"`，方便下游辨别。
+* **磁盘模式（已配置存储路径）**：`_create_info_sharing_run_directory` 会在 `info_sharing_storage_path` 下创建新的时间戳子目录；然后 `_prepare_output_for_disk` 会把每个 AA 块转为普通字典：张量被 `detach()` 后移动到 CPU，并附带 `block_type`、`block_index` 等描述信息。最终 `_write_info_sharing_payload` 使用 `torch.save` 把所有数据写入 `info_sharing_outputs.pt`，并返回存储路径以及 `storage_mode="disk"` 的元数据。
 
-## Converting AA blocks: `_serialize_multi_view_output`
+无论哪种模式，函数都会附带 Transformer 的 `return_type` 与 `info_sharing_type`，使得后续在加载时可以重建当时的推理设置。
 
-This helper is only used in memory mode. It receives a
-`MultiViewTransformerOutput`, clones the `features` tensor as well as the
-optional `additional_token_features`, and records the tensor shapes. If
-`self.info_sharing_storage_device` is set, the clones are moved to that device
-(e.g. CPU for long-lived storage). The returned dictionary mirrors the input
-structure:
+## 转换 AA 块：`_serialize_multi_view_output`
+
+此函数仅在内存模式下使用。它会：
+
+1. 克隆 `MultiViewTransformerOutput` 中的 `features` 张量以及可选的 `additional_token_features`；
+2. 将克隆体移动到 `info_sharing_storage_device` 指定的设备；
+3. 返回一个结构化字典：
 
 ```python
 {
@@ -73,63 +40,39 @@ structure:
 }
 ```
 
-Cloning is crucial: it ensures that subsequent layers cannot mutate the stored
-activations and that the underlying storage device can be changed without
-impacting the original forward pass tensors.
+克隆操作保证了后续网络层不会意外修改缓存激活，同时也允许在不影响原始 forward 张量的情况下迁移存储设备。
 
-## Preparing disk payloads
+## 写盘三部曲
 
-When a storage directory is configured, three helpers participate in writing the
-payload to disk:
+当存在存储目录时，会依次调用三个辅助函数：
 
-1. **`_create_info_sharing_run_directory`** resolves the base path, generates a
-   timestamped run directory (e.g. `2024-05-05T12-34-56`), creates it on disk,
-   and returns the `Path` object. It also removes any stale directory when the
-   flag is disabled to avoid mixing runs.
-2. **`_prepare_output_for_disk`** receives either the final transformer output or
-   a single intermediate block plus a tag (`"final"` or `"intermediate"`) and an
-   optional index. It moves tensors to CPU, detaches them, and packages them in a
-   dictionary with fields such as `block_type`, `block_index`, `features`, and
-   `additional_token_features`.
-3. **`_write_info_sharing_payload`** materialises the `payload` file. It uses
-   `torch.save` to serialize the dictionary to `info_sharing_outputs.pt` inside
-   the run directory. The function returns the final `Path` to aid logging and
-   later inspection.
+1. **`_create_info_sharing_run_directory`**：解析根目录、生成形如 `2024-05-05T12-34-56` 的时间戳子目录并创建；当关闭存储功能时还会清理旧目录，避免不同运行的结果混淆。
+2. **`_prepare_output_for_disk`**：接收最终或单个中间 Transformer 输出，以及标记其类型的 `tag`（如 `"final"`、`"intermediate"`）与可选索引。函数会把张量移至 CPU 并 `detach()`，然后打包成包含 `features`、`additional_token_features`、`block_index`、`block_type` 等字段的字典。
+3. **`_write_info_sharing_payload`**：负责真正落盘，调用 `torch.save` 将聚合后的 `payload` 序列化到运行目录中的 `info_sharing_outputs.pt`。
 
-Combining these helpers ensures that every AA block (final and intermediate) is
-preserved in a single file along with rich metadata.
+通过这一组合，所有 AA 块（最终与各个中间层）都被保存在单个文件中，并带有详尽的上下文信息。
 
-## Accessing cached results: `get_info_sharing_intermediate_features`
+## 访问缓存结果：`get_info_sharing_intermediate_features`
 
-After `_capture_info_sharing_features` executes, the forward pass can expose the
-stored payload through `get_info_sharing_intermediate_features(clear=False)`. In
-memory mode the method returns the cloned `MultiViewTransformerOutput`
-instances, while disk mode returns the metadata describing the on-disk file. The
-optional `clear` flag erases the cached result, which is helpful when repeatedly
-calling `forward` in the same Python session.
+在 `_capture_info_sharing_features` 执行完毕后，可调用 `get_info_sharing_intermediate_features(clear=False)` 获取存储结果：
 
-## Reloading from disk: `load_info_sharing_features_from_file`
+* 内存模式会返回克隆后的 `MultiViewTransformerOutput`；
+* 磁盘模式则返回包含文件路径、块信息、张量形状等的元数据。
 
-To rehydrate a saved run, call
-`load_info_sharing_features_from_file(path, map_location=None, as_outputs=True)`.
-The helper expands the provided `path`, loads the serialized dictionary via
-`torch.load`, and—when `as_outputs` is `True`—wraps each block back into a new
-`MultiViewTransformerOutput`. Returning raw dictionaries is also supported by
-setting `as_outputs=False`, which can be useful for custom tooling or
-non-PyTorch inspection pipelines.
+将 `clear` 设为 `True` 可以在读取后立刻清空缓存，适合在同一 Python 会话中多次调用 `forward`。
 
-## Putting it together
+## 从磁盘重新加载：`load_info_sharing_features_from_file`
 
-1. Enable capture through the Hydra configuration by setting
-   `store_info_sharing_intermediate_features=true` and optionally supplying
-   `info_sharing_storage_path`.
-2. Run inference. The `forward` method saves the transformer outputs using the
-   helper chain described above.
-3. Retrieve the results immediately with
-   `get_info_sharing_intermediate_features` or later by loading the
-   `info_sharing_outputs.pt` artifact with
-   `load_info_sharing_features_from_file`.
+若需重新加载历史运行结果，可调用 `load_info_sharing_features_from_file(path, map_location=None, as_outputs=True)`：
 
-By following these steps you can treat alternating-attention intermediates as a
-first-class artifact, adapt the storage pipeline, or integrate the saved tensors
-into downstream ACE tasks without revisiting the implementation.
+1. 函数会解析 `path` 并通过 `torch.load` 读取 `info_sharing_outputs.pt`；
+2. 当 `as_outputs=True` 时，会把每个块重新封装为新的 `MultiViewTransformerOutput`；
+3. 若设为 `False`，则直接返回原始字典，便于在自定义工具或非 PyTorch 环境中使用。
+
+## 全流程回顾
+
+1. 在 Hydra 配置中开启 `store_info_sharing_intermediate_features=true`，并按需设置 `info_sharing_storage_path`。
+2. 执行推理，`forward` 会调用一系列辅助函数完成特征捕获。
+3. 可立即使用 `get_info_sharing_intermediate_features` 查看结果，或稍后通过 `load_info_sharing_features_from_file` 加载 `info_sharing_outputs.pt`。
+
+理解这套流程后，你可以将 AA 中间特征当作稳定的研究素材，也可以为 ACE 等下游任务构建自己的后处理与可视化工具链。

--- a/docs/seven_scenes_wai_end_to_end_example.md
+++ b/docs/seven_scenes_wai_end_to_end_example.md
@@ -59,6 +59,8 @@ cd -
 
 ```bash
 bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
+    --device cuda \
+    --moge-batch-size 8 \
     "$DATA_ROOT" \
     "$WAI_ROOT" \
     "$CONDA_ENV" \
@@ -67,6 +69,10 @@ bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
 ```
 
 在命令末尾追加 `--datasets chess` 可只转换 `chess` 场景（多个场景可用逗号分隔，例如 `--datasets chess,heads`），便于先运行小规模验证。
+此外：
+
+- `--device` 用于显式指定 GPU/CPU 设备（默认为 `cuda`）。该设置会贯穿转换、共视图计算与 MoGe 推理，便于充分利用 GPU。
+- `--moge-batch-size` 可以放大 MoGe 推理的 batch size，提高 GPU 利用率；若显存不足可调小或直接省略，回落到默认配置。
 
 脚本内部依次调用：
 

--- a/docs/seven_scenes_wai_end_to_end_example.md
+++ b/docs/seven_scenes_wai_end_to_end_example.md
@@ -1,0 +1,153 @@
+# 7Scenes 数据集从下载到 MapAnything 使用的完整示例
+
+本文给出一套可以直接照搬的 7Scenes 工作流，从原始数据下载、PGT 重建到 WAI 转换与 MapAnything 使用。示例命令均假设使用 Bash，并以 `/mnt/storage/xwh/7Scenes` 作为数据根目录，可根据实际情况修改。
+
+## 0. 前置条件
+
+- 已安装 `conda`，并创建好包含 `wai_processing` 依赖的环境，例如 `conda create -n wai_processing python=3.10` 并按仓库要求安装依赖。
+- 安装好 MapAnything 的 Python 依赖，能够运行 `python -m compileall mapanything` 之类的检查。
+- 确保磁盘空间充足（原始压缩包约 40 GB，解压及中间产物约 120 GB）。
+
+为了简化后续命令，可以在 shell 中预先设置：
+
+```bash
+export DATA_ROOT=/mnt/storage/xwh/7Scenes
+export WAI_ROOT=/mnt/storage/xwh/mapanything-dataset/wai_data/7scenes
+export CONDA_ENV=wai_processing
+mkdir -p "$DATA_ROOT" "$WAI_ROOT"
+```
+
+## 1. 下载原始 RGB-D 数据与伪真值仓库
+
+使用仓库提供的脚本一次性下载所有场景并完成两层解压，同时克隆伪真值仓库：
+
+```bash
+python data_processing/wai_processing/download_scripts/download_7scenes.py \
+    --target_dir "$DATA_ROOT/downloads" \
+    --extract_dir "$DATA_ROOT/7scenes_source" \
+    --pgt_dir "$DATA_ROOT/visloc_pseudo_gt_limitations" \
+    --stages download extract pgt
+```
+
+- `downloads/` 会保存官方 ZIP 包。
+- `7scenes_source/` 会展开为 `scene/seq-XX/frame-XXXXXX.*` 的原始结构。
+- `visloc_pseudo_gt_limitations/` 是后续生成 PGT 位姿所需的仓库（可用 `--update_pgt` 更新）。
+
+## 2. 生成 `pgt_7scenes_*` 结构
+
+MapAnything 的转换脚本期待每个场景都已经整理为 `pgt_7scenes_<scene>/<split>/<modality>/` 形式。如果已经有该结构可以跳过本节。
+
+官方 `visloc_pseudo_gt_limitations` 仓库提供了 `setup_7scenes.py` 工具，可以在刚才的 `DATA_ROOT` 中运行：
+
+```bash
+cd "$DATA_ROOT"
+python path/to/setup_7scenes.py \
+    --poses pgt \
+    --depth calibrated \
+    --eye calibrated
+cd -
+```
+
+运行结束后，目录中会出现 `pgt_7scenes_chess/`、`pgt_7scenes_heads/`、`pgt_7scenes_stairs/` 等子目录，分别包含 `train/` 和 `test/` 下的 `rgb/`、`depth/`、`poses/`、`calibration/`（以及可选的 `eye/`）。
+
+> 如果你已经通过自己的脚本完成了同样的重建，只需确保目录命名和文件后缀与上述一致即可。
+
+## 3. 转换为 WAI 数据格式
+
+仓库提供了一键脚本，会将 `pgt_7scenes_*` 转换为 WAI 场景，并生成共视图信息与 MoGe 元数据：
+
+```bash
+bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
+    "$DATA_ROOT" \
+    "$WAI_ROOT" \
+    "$CONDA_ENV" \
+    original_depth_unit=millimeter \
+    default_focal_length=585.0
+```
+
+脚本内部依次调用：
+
+1. `python -m wai_processing.scripts.conversion.seven_scenes` —— 生成符号链接的 RGB、EXR 深度、`scene_meta.json`。
+2. `python -m wai_processing.scripts.covisibility` —— 基于真值深度计算共视图指标。
+3. `python -m wai_processing.scripts.run_moge` —— 生成 MapAnything 下游任务所需的统计量。
+
+转换完成后，`$WAI_ROOT` 下会按场景与序列创建目录，例如 `chess_train_seq-01/`，内部包含 `images/`、`depth/`、`scene_meta.json` 等文件。
+
+## 4. 验证转换结果
+
+可以直接调用数据集类的 CLI 检查统计信息，确认路径与元数据可用：
+
+```bash
+python -m mapanything.datasets.wai.seven_scenes \
+    --root_dir "$WAI_ROOT" \
+    --dataset_metadata_dir /path/to/mapanything_dataset_metadata \
+    --split test \
+    --num_of_views 2
+```
+
+输出会展示样本数量、视角组合情况等。如果加上 `--viz --save /tmp/rr`（需安装 `rerun`），还能快速可视化。
+
+## 5. 在 MapAnything 中使用数据集
+
+### 5.1 运行多视角基准脚本
+
+仓库已经准备好 `configs/dataset/benchmark_518_seven_scenes.yaml`，可以在 `benchmarking/dense_n_view` 基准中直接引用：
+
+```bash
+python benchmarking/dense_n_view/benchmark.py \
+    dataset=benchmark_518_seven_scenes \
+    model=mapanything \
+    model.mapanything.checkpoint_path=/path/to/mapanything.ckpt \
+    root_data_dir="$WAI_ROOT" \
+    machine.mapanything_dataset_metadata_dir=/path/to/mapanything_dataset_metadata \
+    dataset.num_views=2
+```
+
+- `root_data_dir` 会通过 Hydra 传给 `SevenScenesWAI` 加载器。
+- `machine.mapanything_dataset_metadata_dir` 指向预先下载好的公共元数据包。
+- `dataset.num_views` 可以按需改成 1～5，覆盖不同的视角组合数量。
+
+### 5.2 启动训练/微调
+
+若要把 7Scenes 加入训练，只需在调用 `scripts/train.py` 时覆盖训练集定义即可。例如以 512 分辨率、单数据集训练：
+
+```bash
+python scripts/train.py \
+    dataset.train_dataset="[${dataset.seven_scenes_wai.train.dataset_str}]" \
+    dataset.test_dataset="[${dataset.seven_scenes_wai.test.dataset_str}]" \
+    dataset.resolution_train="${dataset.resolution_options.512_4_3_ar}" \
+    dataset.resolution_val="${dataset.resolution_options.512_4_3_ar}" \
+    root_data_dir="$WAI_ROOT" \
+    machine.mapanything_dataset_metadata_dir=/path/to/mapanything_dataset_metadata \
+    model=mapanything \
+    optimizer=adamw \
+    training.max_steps=20000
+```
+
+也可以把 7Scenes 与其他数据集组合，只需把 `dataset.train_dataset` 中的列表换成多个条目即可。
+
+## 6. 目录检查速查表
+
+运行完整流程后，关键目录应类似：
+
+```
+$DATA_ROOT/
+├── downloads/                       # 原始 ZIP
+├── 7scenes_source/                  # 官方解压结果
+├── visloc_pseudo_gt_limitations/    # 伪真值仓库
+├── pgt_7scenes_chess/
+├── pgt_7scenes_heads/
+├── pgt_7scenes_stairs/
+└── ...
+
+$WAI_ROOT/
+├── chess_train_seq-01/
+│   ├── images/seq-01-frame-000000.color.png -> ../../../../7scenes_source/... (符号链接)
+│   ├── depth/seq-01-frame-000000.exr
+│   └── scene_meta.json
+├── chess_test_seq-03/
+├── heads_train_seq-01/
+└── ...
+```
+
+按照以上步骤即可在 MapAnything 中顺利使用 7Scenes 数据集，同时保留原始数据、伪真值和转换后的 WAI 数据。

--- a/docs/seven_scenes_wai_end_to_end_example.md
+++ b/docs/seven_scenes_wai_end_to_end_example.md
@@ -146,17 +146,15 @@ python scripts/train.py \
 1. 首先在服务器端运行脚本，将重建结果写入磁盘：
 
     ```bash
+    DEVICE=cuda NUM_SAMPLES=3 DATA_ROOT="$WAI_ROOT" \
     bash bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh \
-        --device cuda \
-        --num-samples 3 \
-        --data-root "$WAI_ROOT" \
         /path/to/info_sharing_outputs.pt \
         "$WAI_ROOT/demo_runs" \
         model.pretrained=/path/to/mapanything.ckpt \
         machine.mapanything_dataset_metadata_dir=/path/to/mapanything_dataset_metadata
     ```
 
-    - `--indices 10,42,...` 可直接指定想处理的样本索引，脚本会自动忽略 `--num-samples`。
+    - 如果想固定样本，可在命令前添加 `SAMPLE_INDICES=10,42,...`，脚本会自动忽略 `NUM_SAMPLES`。
     - `fusion.stored_feature_file` 通过位置参数提供；其余 Hydra 覆盖（如 `model.pretrained`、`root_data_dir`）可按需追加。
     - 每个样本会生成一个 `<scene>_<split>_<frame>.pt`，内部包含 RGB、相机参数以及融合后的点云/深度信息，并在目录下汇总 `summary.json`。
 

--- a/docs/seven_scenes_wai_end_to_end_example.md
+++ b/docs/seven_scenes_wai_end_to_end_example.md
@@ -61,6 +61,7 @@ cd -
 bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
     --device cuda \
     --moge-batch-size 8 \
+    --moge-model Ruicheng/moge-2-vitl-normal \
     "$DATA_ROOT" \
     "$WAI_ROOT" \
     "$CONDA_ENV" \
@@ -73,12 +74,15 @@ bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
 
 - `--device` 用于显式指定 GPU/CPU 设备（默认为 `cuda`）。该设置会贯穿转换、共视图计算与 MoGe 推理，便于充分利用 GPU。
 - `--moge-batch-size` 可以放大 MoGe 推理的 batch size，提高 GPU 利用率；若显存不足可调小或直接省略，回落到默认配置。
+- `--moge-model` 允许指定 MoGe 权重来源：默认值 `Ruicheng/moge-2-vitl-normal` 会通过 Hugging Face 自动下载；若提前准备好了本地 `model.pt`，可以传入绝对路径免去重复下载。
 
 脚本内部依次调用：
 
 1. `python -m wai_processing.scripts.conversion.seven_scenes` —— 生成符号链接的 RGB、EXR 深度、`scene_meta.json`。
 2. `python -m wai_processing.scripts.covisibility` —— 基于真值深度计算共视图指标。
 3. `python -m wai_processing.scripts.run_moge` —— 生成 MapAnything 下游任务所需的统计量。
+
+如果重复执行该脚本，`scene_meta.json` 中已经标记为 `moge.finished` 的场景会被自动跳过；转换脚本也会检测并复用现有输出，因此不会从零开始重建全部文件。
 
 转换完成后，`$WAI_ROOT` 会按场景与 split（`train`/`test`）聚合生成目录，例如 `chess_train/`、`chess_test/`。每个目录都包含该 split 下所有序列的 `images/`、`depth/` 与统一的 `scene_meta.json` 文件。
 

--- a/docs/seven_scenes_wai_end_to_end_example.md
+++ b/docs/seven_scenes_wai_end_to_end_example.md
@@ -146,16 +146,16 @@ python scripts/train.py \
 1. 首先在服务器端运行脚本，将重建结果写入磁盘：
 
     ```bash
+    STORED_FEATURE_FILE=/path/to/info_sharing_outputs.pt \
+    OUTPUT_ROOT="$WAI_ROOT/demo_runs" \
     DEVICE=cuda NUM_SAMPLES=3 DATA_ROOT="$WAI_ROOT" \
-    bash bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh \
-        /path/to/info_sharing_outputs.pt \
-        "$WAI_ROOT/demo_runs" \
-        model.pretrained=/path/to/mapanything.ckpt \
-        machine.mapanything_dataset_metadata_dir=/path/to/mapanything_dataset_metadata
+    SAMPLE_INDICES=10,42 \
+    HYDRA_OVERRIDES="model.pretrained=/path/to/mapanything.ckpt machine.mapanything_dataset_metadata_dir=/path/to/mapanything_dataset_metadata" \
+    bash bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh
     ```
 
-    - 如果想固定样本，可在命令前添加 `SAMPLE_INDICES=10,42,...`，脚本会自动忽略 `NUM_SAMPLES`。
-    - `fusion.stored_feature_file` 通过位置参数提供；其余 Hydra 覆盖（如 `model.pretrained`、`root_data_dir`）可按需追加。
+    - `SAMPLE_INDICES` 会覆盖 `NUM_SAMPLES`，可留空以顺序取样。
+    - `HYDRA_OVERRIDES` 支持一次性传入多个覆盖项，使用空格分隔即可。
     - 每个样本会生成一个 `<scene>_<split>_<frame>.pt`，内部包含 RGB、相机参数以及融合后的点云/深度信息，并在目录下汇总 `summary.json`。
 
 2. 在本地（例如 WSL）可使用可视化脚本查看或导出 demo 结果：

--- a/docs/seven_scenes_wai_end_to_end_example.md
+++ b/docs/seven_scenes_wai_end_to_end_example.md
@@ -150,7 +150,6 @@ python scripts/train.py \
         --device cuda \
         --num-samples 3 \
         --data-root "$WAI_ROOT" \
-        mapanything \
         /path/to/info_sharing_outputs.pt \
         "$WAI_ROOT/demo_runs" \
         model.pretrained=/path/to/mapanything.ckpt \

--- a/docs/seven_scenes_wai_end_to_end_example.md
+++ b/docs/seven_scenes_wai_end_to_end_example.md
@@ -74,7 +74,7 @@ bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
 2. `python -m wai_processing.scripts.covisibility` —— 基于真值深度计算共视图指标。
 3. `python -m wai_processing.scripts.run_moge` —— 生成 MapAnything 下游任务所需的统计量。
 
-转换完成后，`$WAI_ROOT` 下会按场景与序列创建目录，例如 `chess_train_seq-01/`，内部包含 `images/`、`depth/`、`scene_meta.json` 等文件。
+转换完成后，`$WAI_ROOT` 会按场景与 split（`train`/`test`）聚合生成目录，例如 `chess_train/`、`chess_test/`。每个目录都包含该 split 下所有序列的 `images/`、`depth/` 与统一的 `scene_meta.json` 文件。
 
 ## 4. 验证转换结果
 
@@ -144,12 +144,14 @@ $DATA_ROOT/
 └── ...
 
 $WAI_ROOT/
-├── chess_train_seq-01/
+├── chess_train/
 │   ├── images/seq-01-frame-000000.color.png -> ../../../../7scenes_source/... (符号链接)
+│   ├── images/seq-02-frame-000000.color.png -> ../../../../7scenes_source/... (符号链接)
 │   ├── depth/seq-01-frame-000000.exr
+│   ├── depth/seq-02-frame-000000.exr
 │   └── scene_meta.json
-├── chess_test_seq-03/
-├── heads_train_seq-01/
+├── chess_test/
+├── heads_train/
 └── ...
 ```
 

--- a/docs/seven_scenes_wai_end_to_end_example.md
+++ b/docs/seven_scenes_wai_end_to_end_example.md
@@ -139,6 +139,39 @@ python scripts/train.py \
 
 也可以把 7Scenes 与其他数据集组合，只需把 `dataset.train_dataset` 中的列表换成多个条目即可。
 
+### 5.3 运行 AA 特征融合重建 Demo
+
+如果已经通过 MapAnything 捕获了交替注意力（AA）中间特征（例如利用 `info_sharing_outputs.pt`），可以借助仓库提供的 demo 在 7Scenes 上测试“储存多视角记忆 + 单视角查询”的重建效果。
+
+1. 首先在服务器端运行脚本，将重建结果写入磁盘：
+
+    ```bash
+    bash bash_scripts/tasks/aa_feature_fusion/run_demo_reconstruction.sh \
+        --device cuda \
+        --num-samples 3 \
+        --data-root "$WAI_ROOT" \
+        mapanything \
+        /path/to/info_sharing_outputs.pt \
+        "$WAI_ROOT/demo_runs" \
+        model.pretrained=/path/to/mapanything.ckpt \
+        machine.mapanything_dataset_metadata_dir=/path/to/mapanything_dataset_metadata
+    ```
+
+    - `--indices 10,42,...` 可直接指定想处理的样本索引，脚本会自动忽略 `--num-samples`。
+    - `fusion.stored_feature_file` 通过位置参数提供；其余 Hydra 覆盖（如 `model.pretrained`、`root_data_dir`）可按需追加。
+    - 每个样本会生成一个 `<scene>_<split>_<frame>.pt`，内部包含 RGB、相机参数以及融合后的点云/深度信息，并在目录下汇总 `summary.json`。
+
+2. 在本地（例如 WSL）可使用可视化脚本查看或导出 demo 结果：
+
+    ```bash
+    python scripts/visualization/view_aa_fusion_demo.py \
+        "$WAI_ROOT/demo_runs/chess_test_seq-03-frame-000123.pt" \
+        --save /tmp/chess_demo.png \
+        --export-pts /tmp/chess_demo.ply
+    ```
+
+    脚本默认输出一张包含 RGB 与深度预览的 PNG；如指定 `--show`，则直接弹出窗口。`--export-pts` 会额外写出带颜色的 ASCII PLY 点云，便于在其它工具中进一步分析。
+
 ## 6. 目录检查速查表
 
 运行完整流程后，关键目录应类似：

--- a/docs/seven_scenes_wai_end_to_end_example.md
+++ b/docs/seven_scenes_wai_end_to_end_example.md
@@ -32,6 +32,7 @@ python data_processing/wai_processing/download_scripts/download_7scenes.py \
 - `downloads/` 会保存官方 ZIP 包。
 - `7scenes_source/` 会展开为 `scene/seq-XX/frame-XXXXXX.*` 的原始结构。
 - `visloc_pseudo_gt_limitations/` 是后续生成 PGT 位姿所需的仓库（可用 `--update_pgt` 更新）。
+- 若只是想快速验证流程，可额外指定 `--scenes chess`（或其它场景名），脚本会只下载并解压对应数据。
 
 ## 2. 生成 `pgt_7scenes_*` 结构
 
@@ -64,6 +65,8 @@ bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
     original_depth_unit=millimeter \
     default_focal_length=585.0
 ```
+
+在命令末尾追加 `--datasets chess` 可只转换 `chess` 场景（多个场景可用逗号分隔，例如 `--datasets chess,heads`），便于先运行小规模验证。
 
 脚本内部依次调用：
 

--- a/docs/seven_scenes_wai_pipeline.md
+++ b/docs/seven_scenes_wai_pipeline.md
@@ -17,6 +17,7 @@ python data_processing/wai_processing/download_scripts/download_7scenes.py \
 - `--target_dir`：保存原始 ZIP 压缩包的位置。
 - `--extract_dir`：解压后保留原始目录结构的位置（每个场景包含多个 `seq-XX` 子目录）。
 - `--pgt_dir`：可选参数，用于指定伪真值仓库的克隆路径。加上 `--update_pgt` 可更新已有仓库。
+- `--scenes`：可选参数，若只想快速验证单个场景（例如 `--scenes chess`），可在下载与解压阶段仅处理少量数据。
 
 脚本会自动两层解压所有 ZIP 文件，确保 `7scenes_source/<scene>/seq-XX` 结构完整，供后续生成 `pgt_7scenes_*` 结构时使用。
 
@@ -56,6 +57,8 @@ bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
     /mnt/storage/xwh/mapanything-dataset/wai_data/7scenes \
     wai_processing
 ```
+
+若只想对某几个场景进行转换，可在命令末尾追加 `--datasets chess`（或使用逗号分隔的列表，如 `--datasets chess,heads`）。脚本会自动把该过滤条件传递给转换配置，仅为指定场景生成 WAI 数据。
 
 脚本依次执行：
 
@@ -97,6 +100,7 @@ chess_train_seq-01/
 ## 5. 配置文件与批处理
 
 - `configs/conversion/seven_scenes.yaml`：控制原始路径、默认焦距、深度无效值等参数。
+- 同一配置还新增了 `dataset_whitelist`、`split_whitelist` 与 `sequence_whitelist` 三个可选过滤项，可在调试阶段只转换少量场景、分割或序列；留空即处理全部数据。
 - `configs/launch/seven_scenes.yaml`：提供与其他数据集一致的 SLURM 批处理配置，可在集群上批量运行。
 
 ## 6. 目录组织建议

--- a/docs/seven_scenes_wai_pipeline.md
+++ b/docs/seven_scenes_wai_pipeline.md
@@ -53,12 +53,19 @@ MapAnything 的转换脚本期望看到如下的预处理结果：
 
 ```bash
 bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
+    --device cuda \
+    --moge-batch-size 8 \
     /mnt/storage/xwh/7Scenes \
     /mnt/storage/xwh/mapanything-dataset/wai_data/7scenes \
     wai_processing
 ```
 
-若只想对某几个场景进行转换，可在命令末尾追加 `--datasets chess`（或使用逗号分隔的列表，如 `--datasets chess,heads`）。脚本会自动把该过滤条件传递给转换配置，仅为指定场景生成 WAI 数据。
+若只想对某几个场景进行转换，可在命令末尾追加 `--datasets chess`（或使用逗号分隔的列表，如 `--datasets chess,heads`）。脚本还支持：
+
+- `--device`：显式指定 PyTorch 设备（默认为 `cuda`，可改为 `cpu` 或 `cuda:1` 等）。转换阶段会在该设备上执行深度数据的清理、`covisibility` 计算以及 `MoGe` 推理。
+- `--moge-batch-size`：覆盖 `MoGe` 的推理批大小，值越大越能填满 GPU，但也需要更多显存。
+
+脚本会自动把场景过滤条件和设备配置传递给转换与后处理脚本，仅为指定场景生成 WAI 数据。
 
 脚本依次执行：
 
@@ -83,7 +90,7 @@ pgt_7scenes_chess/
 脚本按以下步骤处理每一帧：
 
 1. **图像链接**：在目标 WAI 目录下创建指向原图像的符号链接，保持零拷贝。
-2. **深度重映射**：读取 16-bit 深度 PNG，将 0 和 65535 视为无效值并归零，剩余深度由毫米转换为米，保存为 EXR 文件（`store_data(..., "depth")`）。
+2. **深度重映射**：读取 16-bit 深度 PNG，将 0 和 65535 视为无效值并归零，剩余深度由毫米转换为米，保存为 EXR 文件（`store_data(..., "depth")`）。若指定 `device=cuda`，掩码和单位转换会在 GPU 上执行，随后再写回 CPU。
 3. **位姿加载**：读取 `*.pose.txt` 中的 4x4 相机到世界变换矩阵，直接写入 `scene_meta.json`。
 4. **相机内参**：从 `*.calibration.txt` 解析 `fx, fy, cx, cy`，若文件为空则回退到配置中定义的默认焦距和图像中心。
 5. **WAI 元数据**：为每个帧生成包含 `image`、`depth`、`transform_matrix` 以及分辨率、焦距、主点等信息的条目。
@@ -104,7 +111,7 @@ chess_train/
 
 ## 5. 配置文件与批处理
 
-- `configs/conversion/seven_scenes.yaml`：控制原始路径、默认焦距、深度无效值等参数。
+- `configs/conversion/seven_scenes.yaml`：控制原始路径、默认焦距、深度无效值等参数，可通过 `device` 字段选择在 CPU 还是 GPU 上执行深度清理。
 - 同一配置还新增了 `dataset_whitelist`、`split_whitelist` 与 `sequence_whitelist` 三个可选过滤项，可在调试阶段只转换少量场景、分割或序列；留空即处理全部数据。
 - `configs/launch/seven_scenes.yaml`：提供与其他数据集一致的 SLURM 批处理配置，可在集群上批量运行。
 
@@ -129,6 +136,6 @@ chess_train/
 
 - 转换脚本默认将深度单位视作毫米，如果自定义数据源请确认单位一致。
 - 若 `calibration` 目录缺失或为空，脚本会回退到配置中的默认焦距（585.0）以及 `(320, 240)` 主点。
-- 运行 `covisibility` 和 `run_moge` 阶段需要 GPU/CPU 资源，建议参考仓库中其他数据集的资源配置。
+- 运行 `covisibility` 和 `run_moge` 阶段需要 GPU/CPU 资源，建议参考仓库中其他数据集的资源配置；必要时可以通过 `--device cpu` 改为纯 CPU 推理。
 
 至此，7Scenes 的下载、处理与 WAI 格式转化流程即告完成。

--- a/docs/seven_scenes_wai_pipeline.md
+++ b/docs/seven_scenes_wai_pipeline.md
@@ -88,14 +88,19 @@ pgt_7scenes_chess/
 4. **相机内参**：从 `*.calibration.txt` 解析 `fx, fy, cx, cy`，若文件为空则回退到配置中定义的默认焦距和图像中心。
 5. **WAI 元数据**：为每个帧生成包含 `image`、`depth`、`transform_matrix` 以及分辨率、焦距、主点等信息的条目。
 
-最终，每个序列（例：`pgt_7scenes_chess/train/seq-01`）会在目标目录下生成一个独立的 WAI 场景目录 `chess_train_seq-01`，内部包含：
+最终，每个场景只会按照 split 聚合为两个子数据集（如 `train` 与 `test`）。
+例如 `pgt_7scenes_chess/train/` 下所有序列会被合并到同一个目标目录 `chess_train/` 中：
 
 ```
-chess_train_seq-01/
+chess_train/
 ├── images/seq-01-frame-000000.color.png -> 原始图像符号链接
+├── images/seq-02-frame-000000.color.png -> 原始图像符号链接
 ├── depth/seq-01-frame-000000.exr
+├── depth/seq-02-frame-000000.exr
 └── scene_meta.json
 ```
+
+`scene_meta.json` 会列出所有来自 `train` split 的帧信息，便于后续统一抽样。
 
 ## 5. 配置文件与批处理
 

--- a/docs/seven_scenes_wai_pipeline.md
+++ b/docs/seven_scenes_wai_pipeline.md
@@ -55,6 +55,7 @@ MapAnything 的转换脚本期望看到如下的预处理结果：
 bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
     --device cuda \
     --moge-batch-size 8 \
+    --moge-model Ruicheng/moge-2-vitl-normal \
     /mnt/storage/xwh/7Scenes \
     /mnt/storage/xwh/mapanything-dataset/wai_data/7scenes \
     wai_processing
@@ -64,6 +65,7 @@ bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
 
 - `--device`：显式指定 PyTorch 设备（默认为 `cuda`，可改为 `cpu` 或 `cuda:1` 等）。转换阶段会在该设备上执行深度数据的清理、`covisibility` 计算以及 `MoGe` 推理。
 - `--moge-batch-size`：覆盖 `MoGe` 的推理批大小，值越大越能填满 GPU，但也需要更多显存。
+- `--moge-model`：覆盖 MoGe 权重路径。默认值为 Hugging Face 仓库 `Ruicheng/moge-2-vitl-normal`；若已手动下载权重文件，可直接传入本地 `.pt` 路径避免重复下载。
 
 脚本会自动把场景过滤条件和设备配置传递给转换与后处理脚本，仅为指定场景生成 WAI 数据。
 
@@ -73,6 +75,8 @@ bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
 2. 运行 `covisibility` 与 `run_moge`，生成与其他数据集一致的附加元数据。
 
 `<conda_env>` 参数用于指定安装了 `wai_processing` 依赖的 Conda 环境，脚本会通过 `conda run` 自动切换环境。
+
+若再次运行该脚本，它会跳过已在 `scene_meta.json` 中标记为 `moge.finished` 的场景，只对未完成的部分重新计算；转换阶段也会复用已存在的 EXR、元数据和符号链接，因此无需担心“从头”覆盖整个数据集。
 
 ## 4. 转换脚本细节
 

--- a/docs/seven_scenes_wai_pipeline.md
+++ b/docs/seven_scenes_wai_pipeline.md
@@ -1,0 +1,125 @@
+# 7Scenes 数据集转化为 WAI 格式流程
+
+本文档总结了如何利用仓库中新添加的脚本，将微软 7Scenes 数据集及其伪真值（Pseudo Ground Truth, PGT）处理成 MapAnything 使用的 WAI 数据格式。整体流程沿袭 MapAnything 既有的数据处理体系，依次完成下载、生成 `pgt_7scenes_*` 目录结构以及 WAI 转换。
+
+## 1. 下载原始数据与伪真值
+
+使用 `download_7scenes.py` 可以一次性下载 7Scenes 官方发布的 RGB-D 序列，并可选地克隆 `visloc_pseudo_gt_limitations` 仓库（其中包含更精确的位姿和焦距信息）。
+
+```bash
+python data_processing/wai_processing/download_scripts/download_7scenes.py \
+    --target_dir /mnt/storage/xwh/7Scenes/downloads \
+    --extract_dir /mnt/storage/xwh/7Scenes/7scenes_source \
+    --pgt_dir /mnt/storage/xwh/7Scenes/visloc_pseudo_gt_limitations \
+    --stages download extract pgt
+```
+
+- `--target_dir`：保存原始 ZIP 压缩包的位置。
+- `--extract_dir`：解压后保留原始目录结构的位置（每个场景包含多个 `seq-XX` 子目录）。
+- `--pgt_dir`：可选参数，用于指定伪真值仓库的克隆路径。加上 `--update_pgt` 可更新已有仓库。
+
+脚本会自动两层解压所有 ZIP 文件，确保 `7scenes_source/<scene>/seq-XX` 结构完整，供后续生成 `pgt_7scenes_*` 结构时使用。
+
+> **提示**：若已经使用现有的 `setup_7scenes.py` 或其它工具生成了 `pgt_7scenes_*` 目录，可直接跳到第 3 节。
+
+## 2. 构建 `pgt_7scenes_*` 目录
+
+MapAnything 的转换脚本期望看到如下的预处理结果：
+
+```
+/mnt/storage/xwh/7Scenes/
+├── pgt_7scenes_chess/
+│   ├── train/
+│   │   ├── rgb/
+│   │   ├── depth/
+│   │   ├── poses/
+│   │   └── calibration/
+│   └── test/
+│       └── ...
+├── pgt_7scenes_heads/
+└── pgt_7scenes_stairs/
+```
+
+如果您已经拥有这一结构，可直接进入下一节。否则，可继续沿用已有的 `setup_7scenes.py`（或自己编写的同等脚本）来：
+
+1. 读取 `visloc_pseudo_gt_limitations` 中的 PGT 位姿与焦距；
+2. 将相应的 RGB、深度、位姿以及焦距信息整理到每个 `pgt_7scenes_<scene>/<split>` 目录下；
+3. （可选）生成与 MapAnything 兼容的符号链接结构。
+
+## 3. 快速运行一键脚本
+
+若希望按照 MapAnything 标准流程一次性完成下载、转换和后处理，可直接运行：
+
+```bash
+bash bash_scripts/data_processing/seven_scenes_to_wai.sh \
+    /mnt/storage/xwh/7Scenes \
+    /mnt/storage/xwh/mapanything-dataset/wai_data/7scenes \
+    wai_processing
+```
+
+脚本依次执行：
+
+1. 调用新的转换脚本 `wai_processing.scripts.conversion.seven_scenes`；
+2. 运行 `covisibility` 与 `run_moge`，生成与其他数据集一致的附加元数据。
+
+`<conda_env>` 参数用于指定安装了 `wai_processing` 依赖的 Conda 环境，脚本会通过 `conda run` 自动切换环境。
+
+## 4. 转换脚本细节
+
+`data_processing/wai_processing/scripts/conversion/seven_scenes.py` 假定 `original_root` 目录内部已经整理为 `pgt_7scenes_*` 布局。例如：
+
+```
+pgt_7scenes_chess/
+└── train/
+    ├── rgb/seq-01-frame-000000.color.png
+    ├── depth/seq-01-frame-000000.depth.png
+    ├── poses/seq-01-frame-000000.pose.txt
+    └── calibration/seq-01-frame-000000.calibration.txt
+```
+
+脚本按以下步骤处理每一帧：
+
+1. **图像链接**：在目标 WAI 目录下创建指向原图像的符号链接，保持零拷贝。
+2. **深度重映射**：读取 16-bit 深度 PNG，将 0 和 65535 视为无效值并归零，剩余深度由毫米转换为米，保存为 EXR 文件（`store_data(..., "depth")`）。
+3. **位姿加载**：读取 `*.pose.txt` 中的 4x4 相机到世界变换矩阵，直接写入 `scene_meta.json`。
+4. **相机内参**：从 `*.calibration.txt` 解析 `fx, fy, cx, cy`，若文件为空则回退到配置中定义的默认焦距和图像中心。
+5. **WAI 元数据**：为每个帧生成包含 `image`、`depth`、`transform_matrix` 以及分辨率、焦距、主点等信息的条目。
+
+最终，每个序列（例：`pgt_7scenes_chess/train/seq-01`）会在目标目录下生成一个独立的 WAI 场景目录 `chess_train_seq-01`，内部包含：
+
+```
+chess_train_seq-01/
+├── images/seq-01-frame-000000.color.png -> 原始图像符号链接
+├── depth/seq-01-frame-000000.exr
+└── scene_meta.json
+```
+
+## 5. 配置文件与批处理
+
+- `configs/conversion/seven_scenes.yaml`：控制原始路径、默认焦距、深度无效值等参数。
+- `configs/launch/seven_scenes.yaml`：提供与其他数据集一致的 SLURM 批处理配置，可在集群上批量运行。
+
+## 6. 目录组织建议
+
+结合用户提供的磁盘布局，可采用如下分层：
+
+```
+/mnt/storage/xwh/7Scenes/
+├── downloads/                 # download_7scenes.py 保存的 zip 包
+├── 7scenes_source/            # 解压后的原始 RGB-D 序列
+├── visloc_pseudo_gt_limitations/  # 克隆的 PGT 仓库
+├── pgt_7scenes_chess/         # 预处理后的目录（可由现有脚本生成）
+├── pgt_7scenes_heads/
+├── pgt_7scenes_stairs/
+└── wai_data/7scenes/          # 转换得到的 WAI 数据集
+```
+
+这样既保持原始数据，也方便后续复用 WAI 数据或再次更新伪真值。
+
+## 7. 额外提示
+
+- 转换脚本默认将深度单位视作毫米，如果自定义数据源请确认单位一致。
+- 若 `calibration` 目录缺失或为空，脚本会回退到配置中的默认焦距（585.0）以及 `(320, 240)` 主点。
+- 运行 `covisibility` 和 `run_moge` 阶段需要 GPU/CPU 资源，建议参考仓库中其他数据集的资源配置。
+
+至此，7Scenes 的下载、处理与 WAI 格式转化流程即告完成。

--- a/mapanything/datasets/__init__.py
+++ b/mapanything/datasets/__init__.py
@@ -19,6 +19,7 @@ from mapanything.datasets.wai.mpsd import MPSDWAI  # noqa
 from mapanything.datasets.wai.mvs_synth import MVSSynthWAI  # noqa
 from mapanything.datasets.wai.paralleldomain4d import ParallelDomain4DWAI  # noqa
 from mapanything.datasets.wai.sailvos3d import SAILVOS3DWAI  # noqa
+from mapanything.datasets.wai.seven_scenes import SevenScenesWAI  # noqa
 from mapanything.datasets.wai.scannetpp import ScanNetPPWAI  # noqa
 from mapanything.datasets.wai.spring import SpringWAI  # noqa
 from mapanything.datasets.wai.tav2_wb import TartanAirV2WBWAI  # noqa

--- a/mapanything/datasets/wai/seven_scenes.py
+++ b/mapanything/datasets/wai/seven_scenes.py
@@ -1,0 +1,236 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the Apache License, Version 2.0
+# found in the LICENSE file in the root directory of this source tree.
+
+"""7Scenes Dataset using WAI format data."""
+
+import os
+from pathlib import Path
+
+import numpy as np
+
+from mapanything.datasets.base.base_dataset import BaseDataset
+from mapanything.utils.wai.core import load_data, load_frame
+
+
+class SevenScenesWAI(BaseDataset):
+    """7Scenes dataset captured with RGB-D sensors and converted to WAI format."""
+
+    def __init__(
+        self,
+        *args,
+        ROOT,
+        dataset_metadata_dir,
+        split,
+        overfit_num_sets=None,
+        sample_specific_scene: bool = False,
+        specific_scene_name: str | None = None,
+        **kwargs,
+    ):
+        """Initialize the dataset attributes."""
+        super().__init__(*args, **kwargs)
+        self.ROOT = ROOT
+        self.dataset_metadata_dir = dataset_metadata_dir
+        self.split = split
+        self.overfit_num_sets = overfit_num_sets
+        self.sample_specific_scene = sample_specific_scene
+        self.specific_scene_name = specific_scene_name
+        self._load_data()
+
+        # 7Scenes provides metric-scale poses derived from pseudo ground truth
+        self.is_metric_scale = True
+        self.is_synthetic = False
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _metadata_path(self) -> Path:
+        return Path(self.dataset_metadata_dir) / self.split / f"seven_scenes_scene_list_{self.split}.npy"
+
+    def _infer_scene_split(self, scene_name: str) -> str | None:
+        parts = scene_name.split("_")
+        if len(parts) >= 3:
+            return parts[1].lower()
+        return None
+
+    def _scan_split_directory(self, split: str) -> list[str]:
+        """Discover scenes on disk when metadata is missing."""
+        root = Path(self.ROOT)
+        if not root.exists():
+            return []
+
+        split_key = split.lower()
+        fallback_splits = [split_key]
+        # Commonly we do not ship a dedicated validation split; fall back to test scenes.
+        if split_key == "val":
+            fallback_splits.append("test")
+
+        scene_names: list[str] = []
+        for entry in sorted(root.iterdir()):
+            if not entry.is_dir():
+                continue
+            scene_split = self._infer_scene_split(entry.name)
+            if scene_split in fallback_splits:
+                scene_names.append(entry.name)
+        return scene_names
+
+    def _maybe_overfit(self, scenes: list[str]) -> list[str]:
+        if self.overfit_num_sets is not None:
+            return scenes[: self.overfit_num_sets]
+        return scenes
+
+    def _ensure_frame_names(self, scene_meta: dict) -> dict:
+        if "frame_names" not in scene_meta:
+            frame_names = {
+                frame["frame_name"]: idx
+                for idx, frame in enumerate(scene_meta.get("frames", []))
+            }
+            scene_meta["frame_names"] = frame_names
+        return scene_meta
+
+    def _load_pairwise_covisibility(self, scene_root: Path, num_views: int) -> np.ndarray:
+        covisibility_root = scene_root / "covisibility"
+        if covisibility_root.exists():
+            for version_dir in sorted(covisibility_root.iterdir()):
+                if not version_dir.is_dir():
+                    continue
+                npy_files = sorted(version_dir.glob("*.npy"))
+                if not npy_files:
+                    continue
+                try:
+                    return load_data(npy_files[0], "mmap")
+                except FileNotFoundError:
+                    continue
+        # Fallback: fully connected graph ensures deterministic sampling when covisibility is unused.
+        return np.ones((num_views, num_views), dtype=np.float32)
+
+    # ------------------------------------------------------------------
+    # Dataset API
+    # ------------------------------------------------------------------
+    def _load_data(self):
+        metadata_path = self._metadata_path()
+        if metadata_path.exists():
+            split_scene_list = list(np.load(metadata_path, allow_pickle=True))
+        else:
+            split_scene_list = self._scan_split_directory(self.split)
+
+        if self.sample_specific_scene and self.specific_scene_name is not None:
+            self.scenes = [self.specific_scene_name]
+        else:
+            self.scenes = self._maybe_overfit(split_scene_list)
+        self.num_of_scenes = len(self.scenes)
+
+    def _get_views(self, sampled_idx, num_views_to_sample, resolution):
+        scene_name = self.scenes[sampled_idx]
+        scene_root = Path(self.ROOT) / scene_name
+        scene_meta = load_data(scene_root / "scene_meta.json", "scene_meta")
+        scene_meta = self._ensure_frame_names(scene_meta)
+
+        scene_file_names = list(scene_meta["frame_names"].keys())
+        num_views_in_scene = len(scene_file_names)
+
+        pairwise_covisibility = self._load_pairwise_covisibility(scene_root, num_views_in_scene)
+        view_indices = self._sample_view_indices(
+            num_views_to_sample,
+            num_views_in_scene,
+            pairwise_covisibility,
+        )
+
+        views = []
+        for view_index in view_indices:
+            view_key = scene_file_names[view_index]
+            view_data = load_frame(
+                scene_root,
+                view_key,
+                modalities=["image", "depth"],
+                scene_meta=scene_meta,
+            )
+
+            image = view_data["image"].permute(1, 2, 0).numpy()
+            image = np.clip(image * 255.0, 0.0, 255.0).astype(np.uint8)
+            depthmap = view_data["depth"].numpy().astype(np.float32)
+            depthmap = np.nan_to_num(depthmap, nan=0.0, posinf=0.0, neginf=0.0)
+            intrinsics = view_data["intrinsics"].numpy().astype(np.float32)
+            camera_pose = view_data["extrinsics"].numpy().astype(np.float32)
+
+            image, depthmap, intrinsics = self._crop_resize_if_necessary(
+                image=image,
+                resolution=resolution,
+                depthmap=depthmap,
+                intrinsics=intrinsics,
+                additional_quantities=None,
+            )
+
+            views.append(
+                dict(
+                    img=image,
+                    depthmap=depthmap,
+                    camera_pose=camera_pose,
+                    camera_intrinsics=intrinsics,
+                    dataset="7Scenes",
+                    label=scene_name,
+                    instance=os.path.join("images", str(view_key)),
+                )
+            )
+
+        return views
+
+
+def get_parser():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-rd", "--root_dir", default="/fsx/xrtech/data/seven_scenes_wai", type=str)
+    parser.add_argument(
+        "-dmd",
+        "--dataset_metadata_dir",
+        default="/fsx/nkeetha/mapanything_dataset_metadata",
+        type=str,
+    )
+    parser.add_argument("-s", "--split", default="test", type=str)
+    parser.add_argument(
+        "-nv",
+        "--num_of_views",
+        default=2,
+        type=int,
+    )
+    parser.add_argument("--viz", action="store_true")
+
+    return parser
+
+
+if __name__ == "__main__":
+    import rerun as rr
+    from tqdm import tqdm
+
+    from mapanything.datasets.base.base_dataset import view_name
+    from mapanything.utils.image import rgb
+    from mapanything.utils.viz import script_add_rerun_args
+
+    parser = get_parser()
+    script_add_rerun_args(parser)
+    args = parser.parse_args()
+
+    dataset = SevenScenesWAI(
+        num_views=args.num_of_views,
+        split=args.split,
+        covisibility_thres=0.0,
+        ROOT=args.root_dir,
+        dataset_metadata_dir=args.dataset_metadata_dir,
+        resolution=(518, 392),
+        transform="imgnorm",
+        data_norm_type="dinov2",
+        seed=777,
+    )
+    print(dataset.get_stats())
+
+    if args.viz:
+        rr.script_setup(args, "SevenScenes_Dataloader")
+        rr.set_time("stable_time", sequence=0)
+        rr.log("world", rr.ViewCoordinates.RDF, static=True)
+
+        for idx in tqdm(range(len(dataset))):
+            views = dataset[idx]
+            for view in views:
+                rr.log(view_name(view), rgb(view["img"]))

--- a/mapanything/datasets/wai/seven_scenes.py
+++ b/mapanything/datasets/wai/seven_scenes.py
@@ -50,7 +50,7 @@ class SevenScenesWAI(BaseDataset):
 
     def _infer_scene_split(self, scene_name: str) -> str | None:
         parts = scene_name.split("_")
-        if len(parts) >= 3:
+        if len(parts) >= 2:
             return parts[1].lower()
         return None
 

--- a/mapanything/models/mapanything/model.py
+++ b/mapanything/models/mapanything/model.py
@@ -8,8 +8,11 @@ MapAnything model class defined using UniCeption modules.
 """
 
 import warnings
+from datetime import datetime
 from functools import partial
-from typing import Any, Callable, Dict, List, Tuple, Type, Union
+from pathlib import Path
+import uuid
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import torch
 import torch.nn as nn
@@ -36,7 +39,10 @@ from uniception.models.info_sharing.alternating_attention_transformer import (
     MultiViewAlternatingAttentionTransformer,
     MultiViewAlternatingAttentionTransformerIFR,
 )
-from uniception.models.info_sharing.base import MultiViewTransformerInput
+from uniception.models.info_sharing.base import (
+    MultiViewTransformerInput,
+    MultiViewTransformerOutput,
+)
 from uniception.models.info_sharing.cross_attention_transformer import (
     MultiViewCrossAttentionTransformer,
     MultiViewCrossAttentionTransformerIFR,
@@ -100,6 +106,9 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
         load_specific_pretrained_submodules: bool = False,
         specific_pretrained_submodules: list = None,
         torch_hub_force_reload: bool = False,
+        store_info_sharing_intermediate_features: bool = False,
+        info_sharing_storage_device: Optional[Union[str, torch.device]] = None,
+        info_sharing_storage_path: Optional[Union[str, Path]] = None,
     ):
         """
         Multi-view model containing an image encoder fused with optional geometric modalities followed by a multi-view attention transformer and respective downstream heads.
@@ -117,6 +126,9 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
             load_specific_pretrained_submodules (bool): Whether to load specific pretrained submodules. (default: False)
             specific_pretrained_submodules (list): List of specific pretrained submodules to load. Must be provided when load_specific_pretrained_submodules is True. (default: None)
             torch_hub_force_reload (bool): Whether to force reload the encoder from torch hub. (default: False)
+            store_info_sharing_intermediate_features (bool): Enable caching the info-sharing transformer's outputs. (default: False)
+            info_sharing_storage_device (str or torch.device, optional): Device to move cached tensors to when storing in memory. Ignored when ``info_sharing_storage_path`` is provided.
+            info_sharing_storage_path (str or Path, optional): Directory where cached info-sharing tensors should be serialized to disk. When set, cached metadata references saved files instead of in-memory tensors.
         """
         super().__init__()
 
@@ -130,6 +142,17 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
         self.load_specific_pretrained_submodules = load_specific_pretrained_submodules
         self.specific_pretrained_submodules = specific_pretrained_submodules
         self.torch_hub_force_reload = torch_hub_force_reload
+        self.store_info_sharing_intermediate_features = (
+            store_info_sharing_intermediate_features
+        )
+        self.info_sharing_storage_device = info_sharing_storage_device
+        self.info_sharing_storage_path = (
+            Path(info_sharing_storage_path).expanduser()
+            if info_sharing_storage_path is not None
+            else None
+        )
+        self._info_sharing_storage_run_dir: Optional[Path] = None
+        self._stored_info_sharing_features: Optional[Dict[str, Any]] = None
         self.class_init_args = {
             "name": self.name,
             "encoder_config": self.encoder_config,
@@ -140,6 +163,11 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
             "load_specific_pretrained_submodules": self.load_specific_pretrained_submodules,
             "specific_pretrained_submodules": self.specific_pretrained_submodules,
             "torch_hub_force_reload": self.torch_hub_force_reload,
+            "store_info_sharing_intermediate_features": self.store_info_sharing_intermediate_features,
+            "info_sharing_storage_device": self.info_sharing_storage_device,
+            "info_sharing_storage_path": str(self.info_sharing_storage_path)
+            if self.info_sharing_storage_path is not None
+            else None,
         }
 
         # Get relevant parameters from the configs
@@ -314,6 +342,16 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
         else:
             raise ValueError(
                 f"Invalid info_sharing_return_type: {self.info_sharing_return_type}. Valid options: ['no_intermediate_features', 'intermediate_features']"
+            )
+
+        if (
+            self.store_info_sharing_intermediate_features
+            and self.info_sharing_return_type != "intermediate_features"
+        ):
+            warnings.warn(
+                "store_info_sharing_intermediate_features=True but info_sharing_return_type is not 'intermediate_features'. "
+                "Only the final information sharing features will be captured.",
+                stacklevel=2,
             )
 
     def _initialize_prediction_heads(self, pred_head_config):
@@ -1501,6 +1539,11 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
 
         Returns:
             List[dict]: A list containing the final outputs for all N views.
+
+        Notes:
+            When ``store_info_sharing_intermediate_features`` is enabled, the final and
+            intermediate multi-view transformer features from this forward pass can be
+            retrieved using :meth:`get_info_sharing_intermediate_features`.
         """
         # Get input shape of the images, number of views, and batch size per view
         batch_size_per_view, _, height, width = views[0]["img"].shape
@@ -1532,6 +1575,9 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
             features=all_encoder_features_across_views,
             additional_input_tokens=input_scale_token,
         )
+        intermediate_info_sharing_multi_view_feat: Optional[
+            List[MultiViewTransformerOutput]
+        ] = None
         if self.info_sharing_return_type == "no_intermediate_features":
             final_info_sharing_multi_view_feat = self.info_sharing(info_sharing_input)
         elif self.info_sharing_return_type == "intermediate_features":
@@ -1539,6 +1585,14 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
                 final_info_sharing_multi_view_feat,
                 intermediate_info_sharing_multi_view_feat,
             ) = self.info_sharing(info_sharing_input)
+
+        if self.store_info_sharing_intermediate_features:
+            self._stored_info_sharing_features = self._capture_info_sharing_features(
+                final_info_sharing_multi_view_feat,
+                intermediate_info_sharing_multi_view_feat,
+            )
+        else:
+            self._stored_info_sharing_features = None
 
         if self.pred_head_type == "linear":
             # Stack the features for all views
@@ -1906,6 +1960,155 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
                     res[i]["non_ambiguous_mask_logits"] = output_mask_logits_per_view[i]
 
         return res
+
+    def _clone_tensor_for_storage(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Detach, clone, and optionally move a tensor for intermediate storage."""
+
+        clone = tensor.detach().clone()
+        target_device = self.info_sharing_storage_device
+        if target_device is not None:
+            try:
+                clone = clone.to(target_device)
+            except (RuntimeError, ValueError) as exc:
+                warnings.warn(
+                    f"Failed to move stored info sharing tensor to '{target_device}': {exc}. Keeping on original device.",
+                    stacklevel=2,
+                )
+        return clone
+
+    def _write_tensor_to_disk(
+        self,
+        tensor: torch.Tensor,
+        run_dir: Path,
+        tag: str,
+        label: str,
+    ) -> Dict[str, Any]:
+        """Serialize a tensor to disk and return its metadata."""
+
+        target_dir = run_dir / tag
+        target_dir.mkdir(parents=True, exist_ok=True)
+        file_path = target_dir / f"{label}.pt"
+        tensor_to_save = tensor.detach().cpu()
+        torch.save(tensor_to_save, file_path)
+        return {
+            "path": str(file_path),
+            "shape": tuple(tensor.shape),
+            "dtype": str(tensor.dtype),
+            "tag": tag,
+            "label": label,
+        }
+
+    def _serialize_multi_view_output(
+        self,
+        output: MultiViewTransformerOutput,
+        run_dir: Optional[Path],
+        tag: str,
+        block_index: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Convert a transformer output into stored metadata or tensors."""
+
+        block_tag = tag
+        if block_index is not None:
+            block_tag = f"{tag}_{block_index:03d}"
+
+        if run_dir is None:
+            return MultiViewTransformerOutput(
+                features=[
+                    self._clone_tensor_for_storage(feature)
+                    for feature in output.features
+                ],
+                additional_token_features=(
+                    self._clone_tensor_for_storage(
+                        output.additional_token_features
+                    )
+                    if output.additional_token_features is not None
+                    else None
+                ),
+            )
+
+        stored_features = [
+            self._write_tensor_to_disk(
+                feature, run_dir, block_tag, f"view_{view_idx:02d}"
+            )
+            for view_idx, feature in enumerate(output.features)
+        ]
+        stored_additional = (
+            self._write_tensor_to_disk(
+                output.additional_token_features,
+                run_dir,
+                block_tag,
+                "additional_tokens",
+            )
+            if output.additional_token_features is not None
+            else None
+        )
+
+        return {
+            "storage": "disk",
+            "tag": block_tag,
+            "block_index": block_index,
+            "features": stored_features,
+            "additional_token_features": stored_additional,
+        }
+
+    def _create_info_sharing_run_directory(self) -> Optional[Path]:
+        if self.info_sharing_storage_path is None:
+            self._info_sharing_storage_run_dir = None
+            return None
+
+        base_dir = self.info_sharing_storage_path
+        base_dir.mkdir(parents=True, exist_ok=True)
+        run_dir = base_dir / (
+            datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+            + f"_{uuid.uuid4().hex[:8]}"
+        )
+        run_dir.mkdir(parents=True, exist_ok=False)
+        self._info_sharing_storage_run_dir = run_dir
+        return run_dir
+
+    def _capture_info_sharing_features(
+        self,
+        final_output: MultiViewTransformerOutput,
+        intermediate_outputs: Optional[List[MultiViewTransformerOutput]],
+    ) -> Dict[str, Any]:
+        """Clone or serialize information sharing outputs for later inspection."""
+
+        run_dir = self._create_info_sharing_run_directory()
+
+        stored: Dict[str, Any] = {
+            "return_type": self.info_sharing_return_type,
+            "info_sharing_type": self.info_sharing_type,
+            "storage_mode": "disk" if run_dir is not None else "memory",
+            "storage_directory": str(run_dir) if run_dir is not None else None,
+            "final": self._serialize_multi_view_output(
+                final_output, run_dir, "final"
+            ),
+        }
+
+        if intermediate_outputs is not None:
+            stored["intermediate"] = [
+                self._serialize_multi_view_output(output, run_dir, "intermediate", idx)
+                for idx, output in enumerate(intermediate_outputs)
+            ]
+        else:
+            stored["intermediate"] = None
+
+        return stored
+
+    def get_info_sharing_intermediate_features(self, clear: bool = False):
+        """Return the cached information sharing features captured during ``forward``.
+
+        When ``info_sharing_storage_path`` is set the returned dictionary contains
+        file metadata (including ``storage_directory`` and per-tensor paths) and the
+        ``storage_mode`` key is ``"disk"``. If the path is ``None`` the dictionary
+        stores ``MultiViewTransformerOutput`` instances and ``storage_mode`` is
+        ``"memory"``.
+        """
+
+        stored = self._stored_info_sharing_features
+        if clear:
+            self._stored_info_sharing_features = None
+        return stored
 
     def _configure_geometric_input_config(
         self,

--- a/mapanything/models/mapanything/model.py
+++ b/mapanything/models/mapanything/model.py
@@ -1976,80 +1976,69 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
                 )
         return clone
 
-    def _write_tensor_to_disk(
-        self,
-        tensor: torch.Tensor,
-        run_dir: Path,
-        tag: str,
-        label: str,
-    ) -> Dict[str, Any]:
-        """Serialize a tensor to disk and return its metadata."""
-
-        target_dir = run_dir / tag
-        target_dir.mkdir(parents=True, exist_ok=True)
-        file_path = target_dir / f"{label}.pt"
-        tensor_to_save = tensor.detach().cpu()
-        torch.save(tensor_to_save, file_path)
-        return {
-            "path": str(file_path),
-            "shape": tuple(tensor.shape),
-            "dtype": str(tensor.dtype),
-            "tag": tag,
-            "label": label,
-        }
-
     def _serialize_multi_view_output(
         self,
         output: MultiViewTransformerOutput,
-        run_dir: Optional[Path],
+    ) -> MultiViewTransformerOutput:
+        """Clone a transformer output for in-memory storage."""
+
+        return MultiViewTransformerOutput(
+            features=[
+                self._clone_tensor_for_storage(feature)
+                for feature in output.features
+            ],
+            additional_token_features=(
+                self._clone_tensor_for_storage(
+                    output.additional_token_features
+                )
+                if output.additional_token_features is not None
+                else None
+            ),
+        )
+
+    def _prepare_output_for_disk(
+        self,
+        output: MultiViewTransformerOutput,
         tag: str,
-        block_index: Optional[int] = None,
+        block_index: Optional[int],
     ) -> Dict[str, Any]:
-        """Convert a transformer output into stored metadata or tensors."""
+        """Detach tensors to CPU and package them for serialization."""
 
-        block_tag = tag
-        if block_index is not None:
-            block_tag = f"{tag}_{block_index:03d}"
-
-        if run_dir is None:
-            return MultiViewTransformerOutput(
-                features=[
-                    self._clone_tensor_for_storage(feature)
-                    for feature in output.features
-                ],
-                additional_token_features=(
-                    self._clone_tensor_for_storage(
-                        output.additional_token_features
-                    )
-                    if output.additional_token_features is not None
-                    else None
-                ),
-            )
-
-        stored_features = [
-            self._write_tensor_to_disk(
-                feature, run_dir, block_tag, f"view_{view_idx:02d}"
-            )
-            for view_idx, feature in enumerate(output.features)
-        ]
-        stored_additional = (
-            self._write_tensor_to_disk(
-                output.additional_token_features,
-                run_dir,
-                block_tag,
-                "additional_tokens",
-            )
+        block_tag = tag if block_index is None else f"{tag}_{block_index:03d}"
+        features = [tensor.detach().cpu() for tensor in output.features]
+        additional = (
+            output.additional_token_features.detach().cpu()
             if output.additional_token_features is not None
             else None
         )
-
         return {
-            "storage": "disk",
             "tag": block_tag,
             "block_index": block_index,
-            "features": stored_features,
-            "additional_token_features": stored_additional,
+            "features": features,
+            "additional_token_features": additional,
         }
+
+    def _summarize_disk_block(self, block: Dict[str, Any]) -> Dict[str, Any]:
+        """Create lightweight metadata for a serialized transformer block."""
+
+        return {
+            "tag": block["tag"],
+            "block_index": block["block_index"],
+            "num_views": len(block["features"]),
+            "feature_shapes": [tuple(tensor.shape) for tensor in block["features"]],
+            "has_additional_tokens": block["additional_token_features"] is not None,
+        }
+
+    def _write_info_sharing_payload(
+        self,
+        run_dir: Path,
+        payload: Dict[str, Any],
+    ) -> Path:
+        """Persist the serialized alternating-attention payload to a single file."""
+
+        file_path = run_dir / "info_sharing_outputs.pt"
+        torch.save(payload, file_path)
+        return file_path
 
     def _create_info_sharing_run_directory(self) -> Optional[Path]:
         if self.info_sharing_storage_path is None:
@@ -2075,23 +2064,54 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
 
         run_dir = self._create_info_sharing_run_directory()
 
-        stored: Dict[str, Any] = {
-            "return_type": self.info_sharing_return_type,
-            "info_sharing_type": self.info_sharing_type,
-            "storage_mode": "disk" if run_dir is not None else "memory",
-            "storage_directory": str(run_dir) if run_dir is not None else None,
-            "final": self._serialize_multi_view_output(
-                final_output, run_dir, "final"
-            ),
-        }
+        if run_dir is None:
+            stored: Dict[str, Any] = {
+                "return_type": self.info_sharing_return_type,
+                "info_sharing_type": self.info_sharing_type,
+                "storage_mode": "memory",
+                "storage_directory": None,
+                "storage_file": None,
+                "final": self._serialize_multi_view_output(final_output),
+                "intermediate": [
+                    self._serialize_multi_view_output(output)
+                    for output in intermediate_outputs
+                ]
+                if intermediate_outputs is not None
+                else None,
+            }
+            return stored
 
-        if intermediate_outputs is not None:
-            stored["intermediate"] = [
-                self._serialize_multi_view_output(output, run_dir, "intermediate", idx)
+        final_block = self._prepare_output_for_disk(final_output, "final", None)
+        intermediate_blocks = (
+            [
+                self._prepare_output_for_disk(output, "intermediate", idx)
                 for idx, output in enumerate(intermediate_outputs)
             ]
-        else:
-            stored["intermediate"] = None
+            if intermediate_outputs is not None
+            else None
+        )
+
+        payload: Dict[str, Any] = {
+            "return_type": self.info_sharing_return_type,
+            "info_sharing_type": self.info_sharing_type,
+            "final": final_block,
+            "intermediate": intermediate_blocks,
+        }
+        storage_file = self._write_info_sharing_payload(run_dir, payload)
+
+        stored = {
+            "return_type": self.info_sharing_return_type,
+            "info_sharing_type": self.info_sharing_type,
+            "storage_mode": "disk",
+            "storage_directory": str(run_dir),
+            "storage_file": str(storage_file),
+            "final": self._summarize_disk_block(final_block),
+            "intermediate": (
+                [self._summarize_disk_block(block) for block in intermediate_blocks]
+                if intermediate_blocks is not None
+                else None
+            ),
+        }
 
         return stored
 
@@ -2099,7 +2119,7 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
         """Return the cached information sharing features captured during ``forward``.
 
         When ``info_sharing_storage_path`` is set the returned dictionary contains
-        file metadata (including ``storage_directory`` and per-tensor paths) and the
+        file metadata (including ``storage_directory`` and ``storage_file``) and the
         ``storage_mode`` key is ``"disk"``. If the path is ``None`` the dictionary
         stores ``MultiViewTransformerOutput`` instances and ``storage_mode`` is
         ``"memory"``.
@@ -2109,6 +2129,55 @@ class MapAnything(nn.Module, PyTorchModelHubMixin):
         if clear:
             self._stored_info_sharing_features = None
         return stored
+
+    @staticmethod
+    def load_info_sharing_features_from_file(
+        path: Union[str, Path],
+        map_location: Optional[Union[str, torch.device]] = None,
+        as_outputs: bool = True,
+    ) -> Dict[str, Any]:
+        """Load serialized alternating-attention features from disk.
+
+        Args:
+            path: File produced by :meth:`_write_info_sharing_payload`.
+            map_location: Optional device mapping forwarded to ``torch.load``.
+            as_outputs: When ``True`` the tensors are wrapped in
+                :class:`MultiViewTransformerOutput` objects. Otherwise, the raw
+                serialized dictionary is returned.
+
+        Returns:
+            Dictionary mirroring the structure of
+            :meth:`get_info_sharing_intermediate_features` but populated with the
+            tensors stored on disk.
+        """
+
+        file_path = Path(path).expanduser()
+        payload = torch.load(file_path, map_location=map_location)
+
+        if not as_outputs:
+            return payload
+
+        def _to_output(block: Optional[Dict[str, Any]]):
+            if block is None:
+                return None
+            return MultiViewTransformerOutput(
+                features=block["features"],
+                additional_token_features=block["additional_token_features"],
+            )
+
+        intermediate_payload = payload.get("intermediate")
+        intermediate_outputs = (
+            [_to_output(block) for block in intermediate_payload]
+            if intermediate_payload is not None
+            else None
+        )
+
+        return {
+            "return_type": payload.get("return_type"),
+            "info_sharing_type": payload.get("info_sharing_type"),
+            "final": _to_output(payload.get("final")),
+            "intermediate": intermediate_outputs,
+        }
 
     def _configure_geometric_input_config(
         self,

--- a/mapanything/tasks/aa_feature_fusion/__init__.py
+++ b/mapanything/tasks/aa_feature_fusion/__init__.py
@@ -1,0 +1,15 @@
+"""AA feature fusion task utilities."""
+
+from .fusion import (
+    AAFeatureFusionModule,
+    StoredAAFeatureSequence,
+    extract_single_view_tokens,
+)
+from .pipeline import AAFeatureFusionPipeline
+
+__all__ = [
+    "AAFeatureFusionModule",
+    "AAFeatureFusionPipeline",
+    "StoredAAFeatureSequence",
+    "extract_single_view_tokens",
+]

--- a/mapanything/tasks/aa_feature_fusion/__init__.py
+++ b/mapanything/tasks/aa_feature_fusion/__init__.py
@@ -1,5 +1,6 @@
 """AA feature fusion task utilities."""
 
+from .builder import build_pipeline_from_cfg
 from .fusion import (
     AAFeatureFusionModule,
     StoredAAFeatureSequence,
@@ -8,6 +9,7 @@ from .fusion import (
 from .pipeline import AAFeatureFusionPipeline
 
 __all__ = [
+    "build_pipeline_from_cfg",
     "AAFeatureFusionModule",
     "AAFeatureFusionPipeline",
     "StoredAAFeatureSequence",

--- a/mapanything/tasks/aa_feature_fusion/builder.py
+++ b/mapanything/tasks/aa_feature_fusion/builder.py
@@ -1,0 +1,32 @@
+"""Helpers to construct AA feature fusion pipelines from Hydra configs."""
+
+from __future__ import annotations
+
+from omegaconf import DictConfig
+
+from mapanything.models.mapanything.model import MapAnything
+
+from .fusion import AAFeatureFusionModule
+from .pipeline import AAFeatureFusionPipeline
+
+
+def build_pipeline_from_cfg(cfg: DictConfig) -> AAFeatureFusionPipeline:
+    """Instantiate the fusion pipeline described by the provided config."""
+
+    base_model = MapAnything(**cfg.model.model_config)
+    fusion_module = AAFeatureFusionModule(
+        stored_feature_file=cfg.fusion.stored_feature_file,
+        num_heads=cfg.fusion.num_heads,
+        mlp_ratio=cfg.fusion.mlp_ratio,
+        dropout=cfg.fusion.dropout,
+        map_location=cfg.fusion.map_location,
+    )
+    pipeline = AAFeatureFusionPipeline(
+        base_model=base_model,
+        fusion_module=fusion_module,
+        include_intrinsics=cfg.single_view.include_intrinsics,
+        include_depth=cfg.single_view.include_depth,
+        include_pose=cfg.single_view.include_pose,
+        include_scale=cfg.single_view.include_scale,
+    )
+    return pipeline

--- a/mapanything/tasks/aa_feature_fusion/demo.py
+++ b/mapanything/tasks/aa_feature_fusion/demo.py
@@ -1,0 +1,272 @@
+"""Run a small AA feature fusion reconstruction demo on 7Scenes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import hydra
+import torch
+from omegaconf import DictConfig
+
+from mapanything import datasets as dataset_registry
+from mapanything.tasks.aa_feature_fusion.builder import build_pipeline_from_cfg
+from mapanything.tasks.aa_feature_fusion.pipeline import AAFeatureFusionPipeline
+from mapanything.utils.geometry import (
+    convert_ray_dirs_depth_along_ray_pose_trans_quats_to_pointmap,
+)
+
+
+def _instantiate_dataset(dataset_str: str):
+    """Instantiate a dataset using the registry side-effects from ``mapanything.datasets``."""
+
+    if isinstance(dataset_str, str):
+        return eval(dataset_str, vars(dataset_registry))
+    raise TypeError(f"Expected dataset_str to be a string, got {type(dataset_str)!r}")
+
+
+def _to_tensor(array: Any, device: torch.device) -> torch.Tensor:
+    if isinstance(array, torch.Tensor):
+        return array.to(device)
+    return torch.as_tensor(array, device=device)
+
+
+def _prepare_view(
+    view: Dict[str, Any],
+    *,
+    device: torch.device,
+    include_intrinsics: bool,
+    include_depth: bool,
+    include_pose: bool,
+    include_scale: bool,
+) -> Dict[str, Any]:
+    """Convert a dataset view dictionary into the tensors required by the model."""
+
+    prepared: Dict[str, Any] = {
+        "img": _to_tensor(view["img"], device=device).unsqueeze(0),
+        "data_norm_type": [view["data_norm_type"]],
+    }
+
+    if include_intrinsics:
+        if "ray_directions_cam" in view:
+            prepared["ray_directions_cam"] = _to_tensor(
+                view["ray_directions_cam"], device=device
+            ).unsqueeze(0)
+        elif "intrinsics" in view:
+            prepared["intrinsics"] = _to_tensor(view["intrinsics"], device=device).unsqueeze(0)
+    if include_depth and "depth_along_ray" in view:
+        prepared["depth_along_ray"] = _to_tensor(view["depth_along_ray"], device=device).unsqueeze(0)
+    if include_pose:
+        if "camera_pose_quats" in view:
+            prepared["camera_pose_quats"] = _to_tensor(
+                view["camera_pose_quats"], device=device
+            ).unsqueeze(0)
+        if "camera_pose_trans" in view:
+            prepared["camera_pose_trans"] = _to_tensor(
+                view["camera_pose_trans"], device=device
+            ).unsqueeze(0)
+    if include_scale:
+        if "is_metric_scale" in view:
+            prepared["is_metric_scale"] = torch.as_tensor(
+                [[bool(view["is_metric_scale"])]], device=device
+            )
+        if "depth_scale" in view:
+            prepared["depth_scale"] = _to_tensor(view["depth_scale"], device=device).unsqueeze(0)
+        if "pose_scale" in view:
+            prepared["pose_scale"] = _to_tensor(view["pose_scale"], device=device).unsqueeze(0)
+    return prepared
+
+
+def _extract_pointmap_like_outputs(
+    pipeline: AAFeatureFusionPipeline,
+    dense_outputs,
+    pose_outputs,
+    scale_output,
+) -> Dict[str, torch.Tensor]:
+    scene_rep_type = pipeline.base_model.scene_rep_type
+    results: Dict[str, torch.Tensor] = {}
+
+    scale_value = scale_output.value
+    scale_hw = scale_value.view(scale_value.shape[0], scale_value.shape[1], 1, 1)
+
+    if scene_rep_type.startswith("pointmap"):
+        pts3d = dense_outputs.value * scale_hw
+        results["pts3d"] = pts3d
+        if hasattr(dense_outputs, "confidence"):
+            results["confidence"] = dense_outputs.confidence
+        if hasattr(dense_outputs, "mask"):
+            results["mask"] = dense_outputs.mask
+    elif scene_rep_type.startswith("raymap+depth"):
+        raymap = dense_outputs.value
+        ray_origins, ray_directions, depth_along_ray = raymap.split([3, 3, 1], dim=1)
+        pts3d = (ray_origins + ray_directions * depth_along_ray) * scale_hw
+        results.update(
+            {
+                "pts3d": pts3d,
+                "ray_origins": ray_origins * scale_hw,
+                "ray_directions": ray_directions,
+                "depth_along_ray": depth_along_ray * scale_hw,
+            }
+        )
+        if hasattr(dense_outputs, "confidence"):
+            results["confidence"] = dense_outputs.confidence
+        if hasattr(dense_outputs, "mask"):
+            results["mask"] = dense_outputs.mask
+    elif scene_rep_type.startswith("raydirs+depth+pose"):
+        if pose_outputs is None:
+            raise RuntimeError("Pose outputs are required for raydirs+depth+pose scene representations.")
+        ray_dirs, depth = dense_outputs.value.split([3, 1], dim=1)
+        cam_trans, cam_quats = pose_outputs.value.split([3, 4], dim=1)
+        pts3d = convert_ray_dirs_depth_along_ray_pose_trans_quats_to_pointmap(
+            ray_dirs.permute(0, 2, 3, 1),
+            depth.permute(0, 2, 3, 1),
+            cam_trans,
+            cam_quats,
+        ).permute(0, 3, 1, 2)
+        pts3d = pts3d * scale_hw
+        results.update(
+            {
+                "pts3d": pts3d,
+                "ray_directions": ray_dirs,
+                "depth_along_ray": depth * scale_hw,
+                "cam_trans": cam_trans * scale_value,
+                "cam_quats": cam_quats,
+            }
+        )
+    elif scene_rep_type.startswith("campointmap+pose"):
+        if pose_outputs is None:
+            raise RuntimeError("Pose outputs are required for campointmap+pose scene representations.")
+        pts3d_cam = dense_outputs.value
+        depth = torch.norm(pts3d_cam, dim=1, keepdim=True)
+        ray_dirs = pts3d_cam / depth.clamp(min=1e-6)
+        cam_trans, cam_quats = pose_outputs.value.split([3, 4], dim=1)
+        pts3d_world = convert_ray_dirs_depth_along_ray_pose_trans_quats_to_pointmap(
+            ray_dirs.permute(0, 2, 3, 1),
+            depth.permute(0, 2, 3, 1),
+            cam_trans,
+            cam_quats,
+        ).permute(0, 3, 1, 2)
+        results.update(
+            {
+                "pts3d": pts3d_world * scale_hw,
+                "pts3d_cam": pts3d_cam,
+                "ray_directions": ray_dirs,
+                "depth_along_ray": depth * scale_hw,
+                "cam_trans": cam_trans * scale_value,
+                "cam_quats": cam_quats,
+            }
+        )
+    else:
+        results["dense_value"] = dense_outputs.value
+    results["scale"] = scale_value
+    return results
+
+
+def run_demo(cfg: DictConfig) -> Dict[str, Any]:
+    pipeline = build_pipeline_from_cfg(cfg)
+    device = torch.device(cfg.demo.device)
+    pipeline.base_model.to(device)
+    pipeline.base_model.eval()
+    pipeline.fusion_module.to(device)
+    pipeline.fusion_module.eval()
+
+    if pipeline.base_model.pred_head_type != "linear":
+        raise NotImplementedError(
+            "The demo currently supports models with linear dense prediction heads."
+        )
+
+    dataset = _instantiate_dataset(cfg.dataset.dataset_str)
+    output_dir = Path(cfg.demo.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    indices: Iterable[int]
+    if cfg.demo.sample_indices is not None:
+        indices = cfg.demo.sample_indices
+    else:
+        indices = range(len(dataset))
+
+    saved_items: List[Dict[str, Any]] = []
+    processed = 0
+
+    for idx in indices:
+        if processed >= cfg.demo.num_samples:
+            break
+        views = dataset[idx]
+        if not views:
+            continue
+        single_view = views[0]
+
+        prepared = _prepare_view(
+            single_view,
+            device=device,
+            include_intrinsics=pipeline.include_intrinsics,
+            include_depth=pipeline.include_depth,
+            include_pose=pipeline.include_pose,
+            include_scale=pipeline.include_scale,
+        )
+
+        with torch.no_grad():
+            fused_tokens = pipeline.fuse(prepared)
+            feature_map = pipeline.fusion_module.tokens_to_feature_map(fused_tokens)
+            scale_token = pipeline.fusion_module.get_additional_token(
+                device=device, dtype=feature_map.dtype
+            )
+            if scale_token is None:
+                scale_token = torch.zeros(
+                    feature_map.shape[0], feature_map.shape[1], 1, device=device, dtype=feature_map.dtype
+                )
+            dense_outputs, pose_outputs, scale_output = pipeline.base_model.downstream_head(
+                dense_head_inputs=feature_map,
+                scale_head_inputs=scale_token,
+                img_shape=feature_map.shape[-2:],
+                memory_efficient_inference=cfg.demo.memory_efficient_inference,
+            )
+
+        reconstruction = _extract_pointmap_like_outputs(
+            pipeline, dense_outputs, pose_outputs, scale_output
+        )
+
+        sample_name = single_view.get("instance", f"sample_{idx:06d}")
+        sample_name = str(sample_name).replace("/", "_")
+        output_path = output_dir / f"{sample_name}.pt"
+
+        record = {
+            "dataset": single_view.get("dataset"),
+            "label": single_view.get("label"),
+            "instance": single_view.get("instance"),
+            "scene_rep_type": pipeline.base_model.scene_rep_type,
+            "rgb": single_view["img"].detach().cpu(),
+            "intrinsics": torch.as_tensor(single_view["camera_intrinsics"]).cpu(),
+            "camera_pose": torch.as_tensor(single_view["camera_pose"]).cpu(),
+            "reconstruction": {k: v.detach().cpu() for k, v in reconstruction.items()},
+        }
+        torch.save(record, output_path)
+
+        saved_items.append(
+            {
+                "index": int(idx),
+                "output": str(output_path),
+                "scene": record["label"],
+                "instance": record["instance"],
+            }
+        )
+        processed += 1
+
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(json.dumps(saved_items, indent=2, ensure_ascii=False))
+    return {"saved": saved_items, "output_dir": str(output_dir)}
+
+
+@hydra.main(
+    version_base=None,
+    config_path="../../../configs/tasks/aa_feature_fusion",
+    config_name="demo",
+)
+def main(cfg: DictConfig) -> None:
+    info = run_demo(cfg)
+    print(json.dumps(info, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/mapanything/tasks/aa_feature_fusion/eval.py
+++ b/mapanything/tasks/aa_feature_fusion/eval.py
@@ -8,12 +8,12 @@ from typing import Any
 import hydra
 from omegaconf import DictConfig
 
-from .train import _build_pipeline
+from .builder import build_pipeline_from_cfg
 
 
 def run_evaluation(cfg: DictConfig) -> Any:
     log = logging.getLogger(__name__)
-    pipeline = _build_pipeline(cfg)
+    pipeline = build_pipeline_from_cfg(cfg)
     log.info("Initialized AA feature fusion pipeline for evaluation.")
     log.info("Dataset config: %s", cfg.dataset)
     log.info("Evaluation parameters: %s", cfg.evaluation)

--- a/mapanything/tasks/aa_feature_fusion/eval.py
+++ b/mapanything/tasks/aa_feature_fusion/eval.py
@@ -1,0 +1,38 @@
+"""Skeleton evaluation loop for alternating-attention feature fusion."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import hydra
+from omegaconf import DictConfig
+
+from .train import _build_pipeline
+
+
+def run_evaluation(cfg: DictConfig) -> Any:
+    log = logging.getLogger(__name__)
+    pipeline = _build_pipeline(cfg)
+    log.info("Initialized AA feature fusion pipeline for evaluation.")
+    log.info("Dataset config: %s", cfg.dataset)
+    log.info("Evaluation parameters: %s", cfg.evaluation)
+    log.info(
+        "Stored AA memory loaded: %s",
+        getattr(pipeline.fusion_module, "has_memory", False),
+    )
+    # Placeholder for evaluation loop.
+    return {"status": "evaluation_loop_not_implemented"}
+
+
+@hydra.main(
+    version_base=None,
+    config_path="../../../configs/tasks/aa_feature_fusion",
+    config_name="test",
+)
+def main(cfg: DictConfig) -> None:
+    run_evaluation(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/mapanything/tasks/aa_feature_fusion/fusion.py
+++ b/mapanything/tasks/aa_feature_fusion/fusion.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Iterator, List, Optional, Sequence
+from typing import Iterable, Iterator, List, Optional, Sequence, Tuple
 
 import torch
 import torch.nn as nn
@@ -48,6 +48,8 @@ class StoredAAFeatureSequence:
 
     memory_tokens: Sequence[torch.Tensor]
     embed_dim: int
+    spatial_shape: Tuple[int, int]
+    additional_token: Optional[torch.Tensor]
 
     @classmethod
     def from_outputs(
@@ -55,14 +57,35 @@ class StoredAAFeatureSequence:
         blocks: Iterable[MultiViewTransformerOutput],
     ) -> "StoredAAFeatureSequence":
         token_groups: List[torch.Tensor] = []
+        spatial_shape: Optional[Tuple[int, int]] = None
+        additional_token: Optional[torch.Tensor] = None
         for block in blocks:
-            per_view_tokens = [_flatten_view_features(feature) for feature in block.features]
+            per_view_tokens = []
+            for feature in block.features:
+                height, width = feature.shape[-2:]
+                if spatial_shape is None:
+                    spatial_shape = (height, width)
+                elif spatial_shape != (height, width):
+                    raise ValueError(
+                        "All alternating-attention blocks must share the same spatial shape; "
+                        f"expected {spatial_shape} but received {(height, width)}"
+                    )
+                per_view_tokens.append(_flatten_view_features(feature))
             memory = torch.cat(per_view_tokens, dim=1)
             token_groups.append(memory.detach())
+            if block.additional_token_features is not None:
+                additional_token = block.additional_token_features.detach()
         if not token_groups:
             raise ValueError("No alternating-attention blocks were provided for memory construction.")
         embed_dim = token_groups[0].shape[-1]
-        return cls(memory_tokens=token_groups, embed_dim=embed_dim)
+        if spatial_shape is None:
+            raise ValueError("Unable to infer spatial shape from alternating-attention blocks.")
+        return cls(
+            memory_tokens=token_groups,
+            embed_dim=embed_dim,
+            spatial_shape=spatial_shape,
+            additional_token=additional_token,
+        )
 
     @classmethod
     def from_file(
@@ -89,6 +112,14 @@ class StoredAAFeatureSequence:
     def num_blocks(self) -> int:
         return len(self.memory_tokens)
 
+    @property
+    def height(self) -> int:
+        return self.spatial_shape[0]
+
+    @property
+    def width(self) -> int:
+        return self.spatial_shape[1]
+
     def iter_tokens(
         self,
         *,
@@ -100,6 +131,21 @@ class StoredAAFeatureSequence:
                 yield tokens.to(device=device, dtype=dtype)
             else:
                 yield tokens
+
+    def reshape_tokens_to_feature_map(self, tokens: torch.Tensor) -> torch.Tensor:
+        """Reshape flattened tokens ``(B, S, C)`` back into ``(B, C, H, W)`` feature maps."""
+
+        batch, sequence, embed_dim = tokens.shape
+        expected_sequence = self.height * self.width
+        if sequence != expected_sequence:
+            raise ValueError(
+                "Token sequence length does not match stored spatial shape: "
+                f"expected {expected_sequence} but received {sequence}"
+            )
+        feature_map = tokens.transpose(1, 2).contiguous().reshape(
+            batch, embed_dim, self.height, self.width
+        )
+        return feature_map
 
 
 class AlternatingAttentionMemoryBlock(nn.Module):
@@ -192,6 +238,7 @@ class AAFeatureFusionModule(nn.Module):
         )
         if self._memory is None:
             self.blocks = nn.ModuleList()
+            self._embed_dim: Optional[int] = None
         else:
             embed_dim = self._memory.embed_dim
             self.blocks = nn.ModuleList(
@@ -205,10 +252,23 @@ class AAFeatureFusionModule(nn.Module):
                     for _ in range(self._memory.num_blocks)
                 ]
             )
+            self._embed_dim = embed_dim
 
     @property
     def has_memory(self) -> bool:
         return self._memory is not None and self._memory.num_blocks > 0
+
+    @property
+    def spatial_shape(self) -> Optional[Tuple[int, int]]:
+        if self._memory is None:
+            return None
+        return self._memory.spatial_shape
+
+    @property
+    def embed_dim(self) -> Optional[int]:
+        if self._memory is None:
+            return None
+        return self._memory.embed_dim
 
     def forward(self, query_tokens: torch.Tensor) -> torch.Tensor:
         if not self.has_memory:
@@ -223,6 +283,25 @@ class AAFeatureFusionModule(nn.Module):
         ):
             fused = block(fused, memory_tokens)
         return fused
+
+    def tokens_to_feature_map(self, tokens: torch.Tensor) -> torch.Tensor:
+        """Convert fused token sequences back into 2D feature maps."""
+
+        if self._memory is None:
+            raise RuntimeError("Cannot reshape tokens without stored alternating-attention memory.")
+        return self._memory.reshape_tokens_to_feature_map(tokens)
+
+    def get_additional_token(
+        self, *, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None
+    ) -> Optional[torch.Tensor]:
+        """Return the stored additional token (e.g., scale token) if available."""
+
+        if self._memory is None or self._memory.additional_token is None:
+            return None
+        token = self._memory.additional_token
+        if device is not None or dtype is not None:
+            token = token.to(device=device, dtype=dtype)
+        return token
 
     def reload(self, path: str | Path, *, map_location: Optional[torch.device | str] = None) -> None:
         """Replace the stored memory with a new alternating-attention capture."""
@@ -256,3 +335,4 @@ class AAFeatureFusionModule(nn.Module):
             )
         self._memory = memory
         self.stored_feature_file = Path(path).expanduser()
+        self._embed_dim = memory.embed_dim

--- a/mapanything/tasks/aa_feature_fusion/fusion.py
+++ b/mapanything/tasks/aa_feature_fusion/fusion.py
@@ -1,0 +1,258 @@
+"""Modules for fusing stored alternating-attention features with single-view inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional, Sequence
+
+import torch
+import torch.nn as nn
+
+from mapanything.models.mapanything.model import MapAnything
+from uniception.models.info_sharing.base import MultiViewTransformerOutput
+
+
+def _flatten_view_features(view_features: torch.Tensor) -> torch.Tensor:
+    """Convert per-view feature maps ``(B, C, H, W)`` into token sequences ``(B, S, C)``."""
+
+    if view_features.dim() != 4:
+        raise ValueError(
+            "Expected a 4D tensor shaped as (batch, channels, height, width) "
+            f"but received {tuple(view_features.shape)}"
+        )
+    batch, channels, height, width = view_features.shape
+    sequence = height * width
+    tokens = view_features.reshape(batch, channels, sequence).transpose(1, 2).contiguous()
+    return tokens
+
+
+def extract_single_view_tokens(
+    model: MapAnything,
+    view: dict,
+    use_autocast: bool = False,
+) -> torch.Tensor:
+    """Run the MapAnything encoders on a single view and return flattened tokens."""
+
+    encoded = model._encode_n_views([view])
+    # Align with ``forward`` by defaulting to full precision during fusion.
+    with torch.autocast("cuda", enabled=use_autocast and torch.cuda.is_available()):
+        fused = model._encode_and_fuse_optional_geometric_inputs([view], encoded)
+    per_view = fused[0]
+    return _flatten_view_features(per_view)
+
+
+@dataclass(frozen=True)
+class StoredAAFeatureSequence:
+    """Container holding the memory tokens reconstructed from stored AA blocks."""
+
+    memory_tokens: Sequence[torch.Tensor]
+    embed_dim: int
+
+    @classmethod
+    def from_outputs(
+        cls,
+        blocks: Iterable[MultiViewTransformerOutput],
+    ) -> "StoredAAFeatureSequence":
+        token_groups: List[torch.Tensor] = []
+        for block in blocks:
+            per_view_tokens = [_flatten_view_features(feature) for feature in block.features]
+            memory = torch.cat(per_view_tokens, dim=1)
+            token_groups.append(memory.detach())
+        if not token_groups:
+            raise ValueError("No alternating-attention blocks were provided for memory construction.")
+        embed_dim = token_groups[0].shape[-1]
+        return cls(memory_tokens=token_groups, embed_dim=embed_dim)
+
+    @classmethod
+    def from_file(
+        cls,
+        path: Optional[Path],
+        *,
+        map_location: Optional[torch.device | str] = None,
+    ) -> Optional["StoredAAFeatureSequence"]:
+        if path is None:
+            return None
+        payload = MapAnything.load_info_sharing_features_from_file(
+            path, map_location=map_location, as_outputs=True
+        )
+        blocks: List[MultiViewTransformerOutput] = []
+        intermediate = payload.get("intermediate")
+        if intermediate:
+            blocks.extend(intermediate)
+        final = payload.get("final")
+        if final is not None:
+            blocks.append(final)
+        return cls.from_outputs(blocks)
+
+    @property
+    def num_blocks(self) -> int:
+        return len(self.memory_tokens)
+
+    def iter_tokens(
+        self,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+    ) -> Iterator[torch.Tensor]:
+        for tokens in self.memory_tokens:
+            if device is not None or dtype is not None:
+                yield tokens.to(device=device, dtype=dtype)
+            else:
+                yield tokens
+
+
+class AlternatingAttentionMemoryBlock(nn.Module):
+    """Single block that mirrors AA frame/global attention using stored memory tokens."""
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        mlp_ratio: float,
+        dropout: float,
+    ) -> None:
+        super().__init__()
+        hidden_dim = int(embed_dim * mlp_ratio)
+
+        self.frame_norm1 = nn.LayerNorm(embed_dim)
+        self.frame_attention = nn.MultiheadAttention(
+            embed_dim, num_heads, dropout=dropout, batch_first=True
+        )
+        self.frame_dropout = nn.Dropout(dropout)
+        self.frame_norm2 = nn.LayerNorm(embed_dim)
+        self.frame_mlp = nn.Sequential(
+            nn.Linear(embed_dim, hidden_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_dim, embed_dim),
+            nn.Dropout(dropout),
+        )
+
+        self.global_norm1 = nn.LayerNorm(embed_dim)
+        self.global_attention = nn.MultiheadAttention(
+            embed_dim, num_heads, dropout=dropout, batch_first=True
+        )
+        self.global_dropout = nn.Dropout(dropout)
+        self.global_norm2 = nn.LayerNorm(embed_dim)
+        self.global_mlp = nn.Sequential(
+            nn.Linear(embed_dim, hidden_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_dim, embed_dim),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, query_tokens: torch.Tensor, memory_tokens: torch.Tensor) -> torch.Tensor:
+        # Frame attention: operate on the single-view tokens only.
+        residual = query_tokens
+        frame_input = self.frame_norm1(query_tokens)
+        attn_output, _ = self.frame_attention(frame_input, frame_input, frame_input, need_weights=False)
+        query_tokens = residual + self.frame_dropout(attn_output)
+        residual = query_tokens
+        mlp_input = self.frame_norm2(query_tokens)
+        query_tokens = residual + self.frame_mlp(mlp_input)
+
+        # Global attention: reuse stored AA block features as keys/values.
+        residual = query_tokens
+        global_input = self.global_norm1(query_tokens)
+        attn_output, _ = self.global_attention(
+            global_input, memory_tokens, memory_tokens, need_weights=False
+        )
+        query_tokens = residual + self.global_dropout(attn_output)
+        residual = query_tokens
+        mlp_input = self.global_norm2(query_tokens)
+        query_tokens = residual + self.global_mlp(mlp_input)
+        return query_tokens
+
+
+class AAFeatureFusionModule(nn.Module):
+    """Fuse single-view tokens with stored alternating-attention memory."""
+
+    def __init__(
+        self,
+        *,
+        stored_feature_file: Optional[str | Path] = None,
+        num_heads: int = 8,
+        mlp_ratio: float = 4.0,
+        dropout: float = 0.0,
+        map_location: Optional[torch.device | str] = None,
+    ) -> None:
+        super().__init__()
+        self.stored_feature_file = (
+            Path(stored_feature_file).expanduser() if stored_feature_file is not None else None
+        )
+        self.map_location = map_location
+        self.num_heads = num_heads
+        self.mlp_ratio = mlp_ratio
+        self.dropout = dropout
+
+        self._memory = StoredAAFeatureSequence.from_file(
+            self.stored_feature_file, map_location=map_location
+        )
+        if self._memory is None:
+            self.blocks = nn.ModuleList()
+        else:
+            embed_dim = self._memory.embed_dim
+            self.blocks = nn.ModuleList(
+                [
+                    AlternatingAttentionMemoryBlock(
+                        embed_dim=embed_dim,
+                        num_heads=num_heads,
+                        mlp_ratio=mlp_ratio,
+                        dropout=dropout,
+                    )
+                    for _ in range(self._memory.num_blocks)
+                ]
+            )
+
+    @property
+    def has_memory(self) -> bool:
+        return self._memory is not None and self._memory.num_blocks > 0
+
+    def forward(self, query_tokens: torch.Tensor) -> torch.Tensor:
+        if not self.has_memory:
+            raise RuntimeError(
+                "AAFeatureFusionModule was constructed without stored alternating-attention memory."
+            )
+
+        fused = query_tokens
+        for block, memory_tokens in zip(
+            self.blocks,
+            self._memory.iter_tokens(device=query_tokens.device, dtype=query_tokens.dtype),
+        ):
+            fused = block(fused, memory_tokens)
+        return fused
+
+    def reload(self, path: str | Path, *, map_location: Optional[torch.device | str] = None) -> None:
+        """Replace the stored memory with a new alternating-attention capture."""
+
+        memory = StoredAAFeatureSequence.from_file(Path(path), map_location=map_location)
+        if memory is None:
+            raise ValueError("The provided alternating-attention file did not contain any feature blocks.")
+        if memory.embed_dim != (self.blocks[0].frame_attention.embed_dim if self.blocks else memory.embed_dim):
+            self.blocks = nn.ModuleList(
+                [
+                    AlternatingAttentionMemoryBlock(
+                        embed_dim=memory.embed_dim,
+                        num_heads=self.num_heads,
+                        mlp_ratio=self.mlp_ratio,
+                        dropout=self.dropout,
+                    )
+                    for _ in range(memory.num_blocks)
+                ]
+            )
+        elif len(self.blocks) != memory.num_blocks:
+            self.blocks = nn.ModuleList(
+                [
+                    AlternatingAttentionMemoryBlock(
+                        embed_dim=memory.embed_dim,
+                        num_heads=self.num_heads,
+                        mlp_ratio=self.mlp_ratio,
+                        dropout=self.dropout,
+                    )
+                    for _ in range(memory.num_blocks)
+                ]
+            )
+        self._memory = memory
+        self.stored_feature_file = Path(path).expanduser()

--- a/mapanything/tasks/aa_feature_fusion/pipeline.py
+++ b/mapanything/tasks/aa_feature_fusion/pipeline.py
@@ -1,0 +1,57 @@
+"""High-level orchestration utilities for alternating-attention feature fusion."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import torch
+
+from mapanything.models.mapanything.model import MapAnything
+
+from .fusion import AAFeatureFusionModule, extract_single_view_tokens
+
+
+class AAFeatureFusionPipeline:
+    """Pipeline that combines stored AA memory with a new single-view input."""
+
+    def __init__(
+        self,
+        *,
+        base_model: MapAnything,
+        fusion_module: AAFeatureFusionModule,
+        include_intrinsics: bool = True,
+        include_depth: bool = False,
+        include_pose: bool = False,
+        include_scale: bool = False,
+    ) -> None:
+        self.base_model = base_model.eval()
+        self.fusion_module = fusion_module
+        self.include_intrinsics = include_intrinsics
+        self.include_depth = include_depth
+        self.include_pose = include_pose
+        self.include_scale = include_scale
+
+    def _filter_view(self, view: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        allowed_keys = {"img", "data_norm_type"}
+        if self.include_intrinsics:
+            allowed_keys.add("ray_directions_cam")
+        if self.include_depth:
+            allowed_keys.add("depth_along_ray")
+        if self.include_pose:
+            allowed_keys.update({"camera_pose_quats", "camera_pose_trans"})
+        if self.include_scale:
+            allowed_keys.update({"is_metric_scale", "depth_scale", "pose_scale"})
+        return {key: value for key, value in view.items() if key in allowed_keys}
+
+    def encode_view(self, view: Dict[str, torch.Tensor]) -> torch.Tensor:
+        filtered_view = self._filter_view(view)
+        return extract_single_view_tokens(self.base_model, filtered_view)
+
+    def fuse(self, view: Dict[str, torch.Tensor]) -> torch.Tensor:
+        with torch.no_grad():
+            tokens = self.encode_view(view)
+            fused = self.fusion_module(tokens)
+        return fused
+
+    def __call__(self, view: Dict[str, torch.Tensor]) -> torch.Tensor:
+        return self.fuse(view)

--- a/mapanything/tasks/aa_feature_fusion/train.py
+++ b/mapanything/tasks/aa_feature_fusion/train.py
@@ -1,0 +1,59 @@
+"""Skeleton training loop for alternating-attention feature fusion."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import hydra
+from omegaconf import DictConfig
+
+def _build_pipeline(cfg: DictConfig):
+    from mapanything.models.mapanything.model import MapAnything
+    from .fusion import AAFeatureFusionModule
+    from .pipeline import AAFeatureFusionPipeline
+
+    base_model = MapAnything(**cfg.model.model_config)
+    fusion_module = AAFeatureFusionModule(
+        stored_feature_file=cfg.fusion.stored_feature_file,
+        num_heads=cfg.fusion.num_heads,
+        mlp_ratio=cfg.fusion.mlp_ratio,
+        dropout=cfg.fusion.dropout,
+        map_location=cfg.fusion.map_location,
+    )
+    pipeline = AAFeatureFusionPipeline(
+        base_model=base_model,
+        fusion_module=fusion_module,
+        include_intrinsics=cfg.single_view.include_intrinsics,
+        include_depth=cfg.single_view.include_depth,
+        include_pose=cfg.single_view.include_pose,
+        include_scale=cfg.single_view.include_scale,
+    )
+    return pipeline
+
+
+def run_training(cfg: DictConfig) -> Any:
+    log = logging.getLogger(__name__)
+    pipeline = _build_pipeline(cfg)
+    log.info("Initialized AA feature fusion pipeline for training.")
+    log.info("Dataset config: %s", cfg.dataset)
+    log.info("Training parameters: %s", cfg.training)
+    log.info(
+        "Stored AA memory loaded: %s",
+        getattr(pipeline.fusion_module, "has_memory", False),
+    )
+    # Placeholder for the actual optimization loop.
+    return {"status": "training_loop_not_implemented"}
+
+
+@hydra.main(
+    version_base=None,
+    config_path="../../../configs/tasks/aa_feature_fusion",
+    config_name="train",
+)
+def main(cfg: DictConfig) -> None:
+    run_training(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/mapanything/tasks/aa_feature_fusion/train.py
+++ b/mapanything/tasks/aa_feature_fusion/train.py
@@ -8,33 +8,12 @@ from typing import Any
 import hydra
 from omegaconf import DictConfig
 
-def _build_pipeline(cfg: DictConfig):
-    from mapanything.models.mapanything.model import MapAnything
-    from .fusion import AAFeatureFusionModule
-    from .pipeline import AAFeatureFusionPipeline
-
-    base_model = MapAnything(**cfg.model.model_config)
-    fusion_module = AAFeatureFusionModule(
-        stored_feature_file=cfg.fusion.stored_feature_file,
-        num_heads=cfg.fusion.num_heads,
-        mlp_ratio=cfg.fusion.mlp_ratio,
-        dropout=cfg.fusion.dropout,
-        map_location=cfg.fusion.map_location,
-    )
-    pipeline = AAFeatureFusionPipeline(
-        base_model=base_model,
-        fusion_module=fusion_module,
-        include_intrinsics=cfg.single_view.include_intrinsics,
-        include_depth=cfg.single_view.include_depth,
-        include_pose=cfg.single_view.include_pose,
-        include_scale=cfg.single_view.include_scale,
-    )
-    return pipeline
+from .builder import build_pipeline_from_cfg
 
 
 def run_training(cfg: DictConfig) -> Any:
     log = logging.getLogger(__name__)
-    pipeline = _build_pipeline(cfg)
+    pipeline = build_pipeline_from_cfg(cfg)
     log.info("Initialized AA feature fusion pipeline for training.")
     log.info("Dataset config: %s", cfg.dataset)
     log.info("Training parameters: %s", cfg.training)

--- a/mapanything/utils/inference.py
+++ b/mapanything/utils/inference.py
@@ -31,6 +31,8 @@ ALLOWED_VIEW_KEYS = {
     "ray_directions",  # Optional - ray directions in camera frame
     "intrinsics",  # Optional - pinhole camera intrinsics (conflicts with ray_directions)
     "camera_poses",  # Optional - camera poses
+    "extrinsics",  # Optional - camera extrinsics (cam2world or world2cam)
+    "extrinsics_type",  # Optional - descriptor for extrinsics convention
     "is_metric_scale",  # Optional - whether inputs are metric scale
     "true_shape",  # Optional - original image shape
     "idx",  # Optional - index of the view
@@ -41,7 +43,8 @@ REQUIRED_KEYS = {"img", "data_norm_type"}
 
 # Define conflicting keys that cannot be used together
 CONFLICTING_KEYS = [
-    ("intrinsics", "ray_directions")  # Both represent camera projection
+    ("intrinsics", "ray_directions"),  # Both represent camera projection
+    ("camera_poses", "extrinsics"),
 ]
 
 
@@ -184,8 +187,13 @@ def validate_input_views_for_inference(
                 )
 
         # Track views with camera poses
-        if "camera_poses" in provided_keys:
+        if "camera_poses" in provided_keys or "extrinsics" in provided_keys:
             views_with_poses.append(view_idx)
+
+        if "extrinsics_type" in provided_keys and "extrinsics" not in provided_keys:
+            raise ValueError(
+                f"View {view_idx} provides 'extrinsics_type' without 'extrinsics'."
+            )
 
     # Cross-view constraint: If any view has camera_poses, view 0 must have them too
     if views_with_poses and 0 not in views_with_poses:
@@ -207,7 +215,7 @@ def preprocess_input_views_for_inference(
     The following steps are performed:
     1. Convert intrinsics to ray directions when required. If ray directions are already provided, unit normalize them.
     2. Convert depth_z to depth_along_ray
-    3. Convert camera_poses to the expected input keys (camera_pose_quats and camera_pose_trans)
+    3. Convert camera_poses / extrinsics to the expected input keys (camera_pose_quats and camera_pose_trans)
     4. Default is_metric_scale to True when not provided
 
     Args:
@@ -250,7 +258,7 @@ def preprocess_input_views_for_inference(
             processed_view["depth_along_ray"] = depth_along_ray
             del processed_view["depth_z"]
 
-        # Step 3: Convert camera_poses to expected input keys
+        # Step 3: Convert camera_poses / extrinsics to expected input keys
         if "camera_poses" in view:
             camera_poses = view["camera_poses"]
             if isinstance(camera_poses, tuple) and len(camera_poses) == 2:
@@ -269,6 +277,46 @@ def preprocess_input_views_for_inference(
                     f"or a tensor of (B, 4, 4) transformation matrices."
                 )
             del processed_view["camera_poses"]
+        elif "extrinsics" in view:
+            extrinsics = view["extrinsics"]
+            extrinsics = torch.as_tensor(
+                extrinsics,
+                device=view["img"].device,
+                dtype=view["img"].dtype,
+            )
+
+            if extrinsics.ndim < 2 or extrinsics.shape[-2] not in (3, 4):
+                raise ValueError(
+                    f"View {view_idx}: extrinsics must have shape (..., 3, 4) or (..., 4, 4)."
+                )
+
+            if extrinsics.ndim == 2:
+                extrinsics = extrinsics.unsqueeze(0)
+
+            if extrinsics.shape[-2:] == (3, 4):
+                last_row = torch.zeros(*extrinsics.shape[:-2], 1, 4, device=extrinsics.device, dtype=extrinsics.dtype)
+                last_row[..., 0, 3] = 1.0
+                extrinsics = torch.cat([extrinsics, last_row], dim=-2)
+
+            extrinsics_type = view.get("extrinsics_type", "cam2world")
+            extrinsics_type = str(extrinsics_type).lower()
+            if extrinsics_type in {"world_to_camera", "world2camera", "w2c"}:
+                pose_mats = torch.linalg.inv(extrinsics)
+            elif extrinsics_type in {"cam2world", "camera_to_world", "c2w"}:
+                pose_mats = extrinsics
+            else:
+                raise ValueError(
+                    f"View {view_idx}: Unknown extrinsics_type '{extrinsics_type}'. "
+                    "Supported values: 'cam2world', 'camera_to_world', 'c2w', 'world_to_camera', 'world2camera', 'w2c'."
+                )
+
+            rotation_matrices = pose_mats[:, :3, :3]
+            translation_vectors = pose_mats[:, :3, 3]
+            quats = rotation_matrix_to_quaternion(rotation_matrices)
+            processed_view["camera_pose_quats"] = quats
+            processed_view["camera_pose_trans"] = translation_vectors
+            del processed_view["extrinsics"]
+            processed_view.pop("extrinsics_type", None)
 
         # Step 4: Default is_metric_scale to True when not provided
         if "is_metric_scale" not in processed_view:

--- a/mapanything/utils/metrics.py
+++ b/mapanything/utils/metrics.py
@@ -419,7 +419,12 @@ def calculate_auc_np(r_error, t_error, max_threshold=30):
     bins = np.arange(max_threshold + 1)
     histogram, _ = np.histogram(max_errors, bins=bins)
     num_pairs = float(len(max_errors))
-    normalized_histogram = histogram.astype(float) / num_pairs
+
+    if num_pairs == 0:
+        normalized_histogram = np.zeros_like(histogram, dtype=float)
+    else:
+        normalized_histogram = histogram.astype(float) / num_pairs
+
     return np.mean(np.cumsum(normalized_histogram)), normalized_histogram
 
 

--- a/scripts/visualization/view_aa_fusion_demo.py
+++ b/scripts/visualization/view_aa_fusion_demo.py
@@ -1,0 +1,120 @@
+"""Utility to visualize AA fusion demo outputs on WSL or local machines."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+
+def _load_sample(path: Path) -> dict:
+    return torch.load(path, map_location="cpu")
+
+
+def _tensor_to_numpy(t: torch.Tensor) -> np.ndarray:
+    return t.detach().cpu().numpy()
+
+
+def _export_ply(points: np.ndarray, colors: Optional[np.ndarray], path: Path) -> None:
+    mask = np.isfinite(points).all(axis=-1)
+    pts = points[mask].reshape(-1, 3)
+    if colors is not None:
+        cols = (np.clip(colors, 0.0, 1.0) * 255.0).astype(np.uint8)
+        cols = cols[mask].reshape(-1, 3)
+    header = [
+        "ply",
+        "format ascii 1.0",
+        f"element vertex {len(pts)}",
+        "property float x",
+        "property float y",
+        "property float z",
+    ]
+    if colors is not None:
+        header.extend(
+            [
+                "property uchar red",
+                "property uchar green",
+                "property uchar blue",
+            ]
+        )
+    header.append("end_header")
+
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write("\n".join(header))
+        fh.write("\n")
+        if colors is None:
+            for x, y, z in pts:
+                fh.write(f"{x:.6f} {y:.6f} {z:.6f}\n")
+        else:
+            for (x, y, z), (r, g, b) in zip(pts, cols, strict=True):
+                fh.write(f"{x:.6f} {y:.6f} {z:.6f} {int(r)} {int(g)} {int(b)}\n")
+
+
+def visualize(sample_path: Path, save_path: Optional[Path], export_pts: Optional[Path], show: bool) -> None:
+    payload = _load_sample(sample_path)
+
+    rgb_tensor = payload.get("rgb")
+    rgb = None
+    if rgb_tensor is not None:
+        rgb = np.clip(_tensor_to_numpy(rgb_tensor).transpose(1, 2, 0), 0.0, 1.0)
+
+    reconstruction = payload.get("reconstruction", {})
+    pts_tensor = reconstruction.get("pts3d")
+    depth_map = None
+    if pts_tensor is not None:
+        pts = _tensor_to_numpy(pts_tensor.squeeze(0)).transpose(1, 2, 0)
+        depth_map = pts[..., 2]
+        if export_pts is not None:
+            colors = rgb if rgb is not None else None
+            _export_ply(pts, colors, export_pts)
+    else:
+        dense = reconstruction.get("dense_value")
+        if dense is not None:
+            depth_map = _tensor_to_numpy(dense.squeeze(0))[0]
+
+    if save_path is None:
+        save_path = sample_path.with_suffix(".png")
+
+    if depth_map is None and rgb is None:
+        raise RuntimeError("No visualization tensors found in the sample payload.")
+
+    fig, axes = plt.subplots(1, 2 if (rgb is not None and depth_map is not None) else 1, figsize=(10, 5))
+    if not isinstance(axes, np.ndarray):
+        axes = np.array([axes])
+
+    axis_idx = 0
+    if rgb is not None:
+        axes[axis_idx].imshow(rgb)
+        axes[axis_idx].set_title("RGB")
+        axes[axis_idx].axis("off")
+        axis_idx += 1
+    if depth_map is not None:
+        axes[axis_idx].imshow(depth_map, cmap="turbo")
+        axes[axis_idx].set_title("Depth / Z")
+        axes[axis_idx].axis("off")
+
+    plt.tight_layout()
+    if show:
+        plt.show()
+    else:
+        fig.savefig(save_path, dpi=200)
+        print(f"Saved visualization to {save_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sample", type=Path, help="Path to a saved demo sample (.pt file)")
+    parser.add_argument("--save", type=Path, default=None, help="Optional path to save the preview PNG")
+    parser.add_argument("--export-pts", type=Path, default=None, help="Optional PLY export for the reconstructed points")
+    parser.add_argument("--show", action="store_true", help="Display the figure instead of saving it")
+    args = parser.parse_args()
+
+    visualize(args.sample, args.save, args.export_pts, args.show)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a dedicated ACE alternating-attention capture preset that writes tensors into an ACE-scoped directory tree
- provide an ACE helper script so Hydra runs no longer store intermediate tensors under the benchmarking workspace
- document both presets so users can choose between benchmark-aligned and ACE-isolated storage

## Testing
- python -m compileall mapanything/models/mapanything/model.py

------
https://chatgpt.com/codex/tasks/task_e_6905a3000e088326a1ba6c4a0519f402